### PR TITLE
Adjust expense amount type for SQLite

### DIFF
--- a/pages/api/expenses/[id].ts
+++ b/pages/api/expenses/[id].ts
@@ -38,7 +38,7 @@ async function updateExpense(req: NextApiRequest, res: NextApiResponse) {
     if (!numericAmount || Number.isNaN(numericAmount) || numericAmount <= 0) {
       return res.status(400).json({ message: 'Сумма должна быть больше 0' });
     }
-    data.amount = numericAmount.toFixed(2);
+    data.amount = numericAmount;
   }
 
   if (description !== undefined) {

--- a/pages/api/expenses/index.ts
+++ b/pages/api/expenses/index.ts
@@ -107,7 +107,7 @@ async function createExpense(req: NextApiRequest, res: NextApiResponse) {
 
   const expense = await prisma.expense.create({
     data: {
-      amount: numericAmount.toFixed(2),
+      amount: numericAmount,
       categoryId: categoryId ?? null,
       description: description ?? null,
       date: parsedDate,

--- a/prisma/migrations/0002_adjust-expense-amount-type/migration.sql
+++ b/prisma/migrations/0002_adjust-expense-amount-type/migration.sql
@@ -1,0 +1,23 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Expense" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "userId" TEXT NOT NULL,
+    "categoryId" TEXT,
+    "amount" REAL NOT NULL,
+    "description" TEXT,
+    "date" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Expense_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "Expense_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "Category" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+INSERT INTO "new_Expense" ("id", "userId", "categoryId", "amount", "description", "date", "createdAt")
+SELECT "id", "userId", "categoryId", "amount", "description", "date", "createdAt" FROM "Expense";
+DROP TABLE "Expense";
+ALTER TABLE "new_Expense" RENAME TO "Expense";
+CREATE INDEX "Expense_userId_idx" ON "Expense"("userId");
+CREATE INDEX "Expense_categoryId_idx" ON "Expense"("categoryId");
+CREATE INDEX "Expense_date_idx" ON "Expense"("date");
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys=ON;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -40,7 +40,7 @@ model Expense {
   userId      String
   category    Category? @relation(fields: [categoryId], references: [id], onDelete: SetNull)
   categoryId  String?
-  amount      Decimal   @db.Decimal(12, 2)
+  amount      Float
   description String?
   date        DateTime  @default(now())
   createdAt   DateTime  @default(now())


### PR DESCRIPTION
## Summary
- switch the Prisma Expense.amount field to a Float to match SQLite support and add a migration updating the table
- keep expense API handlers working with raw numeric amounts rather than formatting strings so responses remain numeric

## Testing
- npm run lint
- npx prisma generate *(fails: binaries.prisma.sh returns 403 when downloading engines)*

------
https://chatgpt.com/codex/tasks/task_e_68ddc52b7b208330bf67969b00521b00