### PR TITLE
Scope BreakdownList heading styles

### DIFF
--- a/components/BreakdownList.module.css
+++ b/components/BreakdownList.module.css
@@ -8,7 +8,7 @@
   gap: 16px;
 }
 
-h3 {
+.title {
   margin: 0;
   font-size: 18px;
 }

--- a/components/BreakdownList.tsx
+++ b/components/BreakdownList.tsx
@@ -17,7 +17,7 @@ interface Props {
 export function BreakdownList({ items }: Props) {
   return (
     <div className={styles.container}>
-      <h3>Топ расходов</h3>
+      <h3 className={styles.title}>Топ расходов</h3>
       <ul className={styles.list}>
         {items.map((item) => (
           <li key={item.id} className={styles.item}>


### PR DESCRIPTION
## Summary
- replace the global BreakdownList heading selector with a scoped `.title` class in the CSS module
- apply the scoped heading class within `BreakdownList.tsx` to avoid CSS module purity errors

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68ddc732495083308527a1c8a0233a31