### PR TITLE
Fix StreakCard typography selectors

### DIFF
--- a/components/StreakCard.module.css
+++ b/components/StreakCard.module.css
@@ -8,12 +8,12 @@
   gap: 12px;
 }
 
-h3 {
+.title {
   margin: 0;
   font-size: 18px;
 }
 
-p {
+.description {
   margin: 0;
   color: rgba(8, 253, 216, 0.8);
   font-size: 14px;

--- a/components/StreakCard.tsx
+++ b/components/StreakCard.tsx
@@ -7,8 +7,8 @@ interface Props {
 export function StreakCard({ streak }: Props) {
   return (
     <div className={styles.card}>
-      <h3>Игровой прогресс</h3>
-      <p>
+      <h3 className={styles.title}>Игровой прогресс</h3>
+      <p className={styles.description}>
         Вы отмечали финансовые действия {streak} {decline(streak, ['день подряд', 'дня подряд', 'дней подряд'])}. Продолжайте streak,
         чтобы удерживать целевую аллокацию и получать больше очков.
       </p>


### PR DESCRIPTION
## Summary
- replace the generic `h3` and `p` selectors in the StreakCard stylesheet with uniquely named classes
- apply the new classes to the StreakCard heading and description elements

## Testing
- `npm run build` *(fails: existing type error in pages/api/analytics/overview.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68ddc82961e0833087d34573478c2d68