### PR TITLE
Add explicit relation for user portfolio connections

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,25 +13,26 @@ enum CategoryType {
 }
 
 model User {
-  id            String     @id @default(cuid())
-  email         String     @unique
-  name          String
-  passwordHash  String
-  createdAt     DateTime   @default(now())
-  categories    Category[]
-  expenses      Expense[]
+  id                   String                @id @default(cuid())
+  email                String                @unique
+  name                 String
+  passwordHash         String
+  createdAt            DateTime              @default(now())
+  categories           Category[]
+  expenses             Expense[]
+  portfolioConnections PortfolioConnection[] @relation("UserPortfolioConnections")
 }
 
 model Category {
-  id         String        @id @default(cuid())
-  name       String
-  type       CategoryType  @default(EXPENSE)
-  budget     Int?
-  color      String?
-  user       User          @relation(fields: [userId], references: [id], onDelete: Cascade)
-  userId     String
-  createdAt  DateTime      @default(now())
-  expenses   Expense[]
+  id        String       @id @default(cuid())
+  name      String
+  type      CategoryType @default(EXPENSE)
+  budget    Int?
+  color     String?
+  user      User         @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId    String
+  createdAt DateTime     @default(now())
+  expenses  Expense[]
 }
 
 model Expense {
@@ -47,60 +48,59 @@ model Expense {
 }
 
 model PortfolioConnection {
-  id            String                @id @default(cuid())
-  user          User                  @relation(fields: [userId], references: [id], onDelete: Cascade)
-  userId        String
-  token         String
-  accountId     String?
+  id                String               @id @default(cuid())
+  user              User                 @relation("UserPortfolioConnections", fields: [userId], references: [id], onDelete: Cascade)
+  userId            String
+  token             String
+  accountId         String?
   brokerAccountType String?
-  createdAt     DateTime              @default(now())
-  updatedAt     DateTime              @updatedAt
-  lastSyncedAt  DateTime?
-  snapshots     PortfolioSnapshot[]
-  positions     PortfolioPosition[]
-  operations    PortfolioOperation[]
-  dividends     PortfolioDividend[]
+  createdAt         DateTime             @default(now())
+  updatedAt         DateTime             @updatedAt
+  lastSyncedAt      DateTime?
+  snapshots         PortfolioSnapshot[]
+  positions         PortfolioPosition[]
+  operations        PortfolioOperation[]
+  dividends         PortfolioDividend[]
 
   @@unique([userId])
 }
 
-
 model PortfolioSnapshot {
-  id            String               @id @default(cuid())
-  connection    PortfolioConnection  @relation(fields: [connectionId], references: [id], onDelete: Cascade)
+  id            String              @id @default(cuid())
+  connection    PortfolioConnection @relation(fields: [connectionId], references: [id], onDelete: Cascade)
   connectionId  String
   capturedAt    DateTime
   totalAmount   Float
   expectedYield Float?
   currency      String
-  createdAt     DateTime             @default(now())
+  createdAt     DateTime            @default(now())
 
   @@index([connectionId, capturedAt])
 }
 
 model PortfolioPosition {
-  id                       String               @id @default(cuid())
-  connection               PortfolioConnection  @relation(fields: [connectionId], references: [id], onDelete: Cascade)
-  connectionId             String
-  figi                     String
-  ticker                   String?
-  name                     String?
-  instrumentType           String?
-  balance                  Float
-  lot                      Float?
-  currentPrice             Float?
-  averagePositionPrice     Float?
-  expectedYield            Float?
-  expectedYieldPercent     Float?
-  currency                 String?
-  updatedAt                DateTime             @default(now())
+  id                   String              @id @default(cuid())
+  connection           PortfolioConnection @relation(fields: [connectionId], references: [id], onDelete: Cascade)
+  connectionId         String
+  figi                 String
+  ticker               String?
+  name                 String?
+  instrumentType       String?
+  balance              Float
+  lot                  Float?
+  currentPrice         Float?
+  averagePositionPrice Float?
+  expectedYield        Float?
+  expectedYieldPercent Float?
+  currency             String?
+  updatedAt            DateTime            @default(now())
 
   @@index([connectionId, figi])
 }
 
 model PortfolioOperation {
-  id             String               @id @default(cuid())
-  connection     PortfolioConnection  @relation(fields: [connectionId], references: [id], onDelete: Cascade)
+  id             String              @id @default(cuid())
+  connection     PortfolioConnection @relation(fields: [connectionId], references: [id], onDelete: Cascade)
   connectionId   String
   operationId    String
   figi           String?
@@ -114,15 +114,15 @@ model PortfolioOperation {
   date           DateTime
   description    String?
   commission     Float?
-  createdAt      DateTime             @default(now())
+  createdAt      DateTime            @default(now())
 
   @@unique([connectionId, operationId])
   @@index([connectionId, date])
 }
 
 model PortfolioDividend {
-  id           String               @id @default(cuid())
-  connection   PortfolioConnection  @relation(fields: [connectionId], references: [id], onDelete: Cascade)
+  id           String              @id @default(cuid())
+  connection   PortfolioConnection @relation(fields: [connectionId], references: [id], onDelete: Cascade)
   connectionId String
   figi         String?
   ticker       String?
@@ -130,7 +130,7 @@ model PortfolioDividend {
   currency     String?
   paymentDate  DateTime
   recordDate   DateTime?
-  createdAt    DateTime             @default(now())
+  createdAt    DateTime            @default(now())
 
   @@index([connectionId, paymentDate])
 }


### PR DESCRIPTION
## Summary
- add an explicit `portfolioConnections` relation on the `User` model
- align the `PortfolioConnection.user` relation to use the shared relation name
- format the Prisma schema to normalize layout

## Testing
- npx prisma format
- PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 npx prisma generate

------
https://chatgpt.com/codex/tasks/task_e_68defa56d5f883308cb732f1aa9661ce