### PR TITLE
Update T-Bank Invest defaults and clarify SDK errors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 DATABASE_URL="file:./dev.db"
 JWT_SECRET="super-secret-change-me"
-TBANK_INVEST_API_URL="https://api-invest.tinkoff.ru/openapi"
-TBANK_INVEST_SOCKET_URL="wss://api-invest.tinkoff.ru/openapi/md/v1/md-openapi/ws"
+TBANK_INVEST_API_URL="https://api-invest.tbank.ru/openapi"
+TBANK_INVEST_SOCKET_URL="wss://api-invest.tbank.ru/openapi/md/v1/md-openapi/ws"
 

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ npm run dev
 
 - `DATABASE_URL` — путь к базе SQLite (по умолчанию `file:./dev.db`).
 - `JWT_SECRET` — секрет для подписи токенов (обязательно заменить в продакшене).
-- `TBANK_INVEST_API_URL` — базовый URL REST API T-Bank Invest (по умолчанию публичный prod endpoint).
-- `TBANK_INVEST_SOCKET_URL` — URL вебсокет-потока котировок (по умолчанию публичный prod endpoint).
+- `TBANK_INVEST_API_URL` — базовый URL REST API T-Bank Invest (по умолчанию `https://api-invest.tbank.ru/openapi`).
+- `TBANK_INVEST_SOCKET_URL` — URL вебсокет-потока котировок (по умолчанию `wss://api-invest.tbank.ru/openapi/md/v1/md-openapi/ws`).
 
 ## Работа с портфелем
 


### PR DESCRIPTION
## Summary
- point REST and streaming defaults at the new api-invest.tbank.ru host while preserving env overrides
- add defensive handling for non-JSON responses from the Invest SDK with a clearer base URL error
- refresh env docs and example configuration to mention the new tbank.ru endpoints

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68defd7d14d88330aec763f48194860e