### PR TITLE
feat: refresh T-Bank endpoint defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 DATABASE_URL="file:./dev.db"
 JWT_SECRET="super-secret-change-me"
+# Remove these lines to fall back to the default T-Bank Invest endpoints unless you
+# need to point at a different environment.
 TBANK_INVEST_API_URL="https://api-invest.tbank.ru/openapi"
 TBANK_INVEST_SOCKET_URL="wss://api-invest.tbank.ru/openapi/md/v1/md-openapi/ws"
 

--- a/README.md
+++ b/README.md
@@ -38,8 +38,10 @@ npm run dev
 
 - `DATABASE_URL` — путь к базе SQLite (по умолчанию `file:./dev.db`).
 - `JWT_SECRET` — секрет для подписи токенов (обязательно заменить в продакшене).
-- `TBANK_INVEST_API_URL` — базовый URL REST API T-Bank Invest (по умолчанию `https://api-invest.tbank.ru/openapi`).
-- `TBANK_INVEST_SOCKET_URL` — URL вебсокет-потока котировок (по умолчанию `wss://api-invest.tbank.ru/openapi/md/v1/md-openapi/ws`).
+- `TBANK_INVEST_API_URL` — базовый URL REST API T-Bank Invest (по умолчанию `https://api-invest.tbank.ru/openapi`; удалите переменную из `.env`, чтобы использовать значение по умолчанию).
+- `TBANK_INVEST_SOCKET_URL` — URL вебсокет-потока котировок (по умолчанию `wss://api-invest.tbank.ru/openapi/md/v1/md-openapi/ws`; удалите переменную из `.env`, чтобы использовать значение по умолчанию).
+
+> ℹ️ Если вы обновляете существующий деплой, освежите локальные и продакшн `.env` файлы (например, пересоздайте их из `.env.example` или удалите старые значения `TBANK_INVEST_API_URL`/`TBANK_INVEST_SOCKET_URL`), чтобы приложение могло использовать новые значения по умолчанию.
 
 ## Работа с портфелем
 

--- a/lib/tbank.ts
+++ b/lib/tbank.ts
@@ -7,9 +7,11 @@ import type {
 
 import { prisma } from './prisma';
 
-const DEFAULT_REST_URL = process.env.TBANK_INVEST_API_URL ?? 'https://api-invest.tbank.ru/openapi';
+const DEFAULT_REST_URL =
+  process.env.TBANK_INVEST_API_URL?.trim() || 'https://api-invest.tbank.ru/openapi';
 const DEFAULT_STREAM_URL =
-  process.env.TBANK_INVEST_SOCKET_URL ?? 'wss://api-invest.tbank.ru/openapi/md/v1/md-openapi/ws';
+  process.env.TBANK_INVEST_SOCKET_URL?.trim() ||
+  'wss://api-invest.tbank.ru/openapi/md/v1/md-openapi/ws';
 
 const TBANK_API_INVALID_BASE_URL_CODE = 'TBANK_API_INVALID_BASE_URL';
 


### PR DESCRIPTION
## Summary
- ensure the T-Bank REST and streaming clients fall back to the production endpoints when environment variables are blank or omitted
- document the default T-Bank endpoints in `.env.example` and explain how to rely on them via the README
- remind operators to refresh their `.env` files so the new defaults are applied

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68deff23c490833095f4c0ed3233284b