### PR TITLE
Add timeframe filter and adjust portfolio chart scaling

### DIFF
--- a/components/PortfolioChart.module.css
+++ b/components/PortfolioChart.module.css
@@ -40,6 +40,34 @@
   padding: 8px 12px;
 }
 
+.timeframeGroup {
+  display: flex;
+  gap: 8px;
+  background: rgba(255, 255, 255, 0.06);
+  padding: 4px;
+  border-radius: 12px;
+}
+
+.timeframeButton {
+  background: transparent;
+  border: none;
+  color: rgba(255, 255, 255, 0.65);
+  font-size: 13px;
+  padding: 6px 10px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.timeframeButton:hover {
+  color: #fff;
+}
+
+.timeframeButtonActive {
+  background: rgba(56, 189, 248, 0.16);
+  color: #fff;
+}
+
 .metric {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- add preset timeframe controls to the portfolio chart and filter visible points accordingly
- improve axis domain calculation so the chart reflects actual portfolio value dynamics
- update styling for new timeframe buttons and keep the area chart baseline at the data minimum

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2a3a233688330bf16057d84d0dd83