### PR TITLE
Split income and expense tracking and update charts

### DIFF
--- a/components/CategoryList.module.css
+++ b/components/CategoryList.module.css
@@ -5,6 +5,12 @@
   padding: 24px;
   display: flex;
   flex-direction: column;
+  gap: 32px;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
   gap: 20px;
 }
 
@@ -25,6 +31,12 @@
   display: flex;
   flex-direction: column;
   gap: 16px;
+}
+
+.placeholder {
+  margin: 0;
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.55);
 }
 
 .item {
@@ -74,6 +86,22 @@
 .actions {
   display: flex;
   gap: 8px;
+}
+
+.incomeWrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.incomeValue {
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.incomeMeta {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.55);
 }
 
 .actions button {

--- a/components/CategoryList.tsx
+++ b/components/CategoryList.tsx
@@ -9,6 +9,7 @@ interface Category {
   type: 'INCOME' | 'EXPENSE';
   budget: number | null;
   spent?: number;
+  earned?: number;
   progress?: number | null;
   color?: string | null;
 }
@@ -78,43 +79,94 @@ export function CategoryList({ categories, onChanged }: Props) {
     onChanged();
   }
 
+  const expenseCategories = categories.filter((category) => category.type === 'EXPENSE');
+  const incomeCategories = categories.filter((category) => category.type === 'INCOME');
+
   return (
     <div className={styles.container}>
-      <header className={styles.header}>
-        <span>Категории</span>
-        <span className={styles.caption}>Лимиты и прогресс расходов</span>
-      </header>
-      <div className={styles.list}>
-        {categories.map((category) => (
-          <div key={category.id} className={styles.item}>
-            <div className={styles.info}>
-              <div className={styles.icon} style={{ background: category.color ?? '#272637' }} />
-              <div>
-                <div className={styles.name}>{category.name}</div>
-                <div className={styles.meta}>{category.type === 'INCOME' ? 'Доход' : 'Расход'}</div>
+      <section className={styles.section}>
+        <header className={styles.header}>
+          <span>Категории расходов</span>
+          <span className={styles.caption}>Лимиты и прогресс расходов</span>
+        </header>
+        {expenseCategories.length ? (
+          <div className={styles.list}>
+            {expenseCategories.map((category) => (
+              <div key={category.id} className={styles.item}>
+                <div className={styles.info}>
+                  <div className={styles.icon} style={{ background: category.color ?? '#272637' }} />
+                  <div>
+                    <div className={styles.name}>{category.name}</div>
+                    <div className={styles.meta}>Расход</div>
+                  </div>
+                </div>
+                <div className={styles.progressWrapper}>
+                  <ProgressBar value={category.progress ?? 0} color={category.color ?? undefined} />
+                  <div className={styles.progressText}>
+                    {(category.spent ?? 0).toLocaleString('ru-RU')} ₽
+                    {category.budget
+                      ? ` из ${category.budget.toLocaleString('ru-RU')} ₽`
+                      : ' • без лимита'}
+                  </div>
+                </div>
+                <div className={styles.actions}>
+                  <button type="button" onClick={() => handleRename(category.id, category.name)}>
+                    Переименовать
+                  </button>
+                  <button type="button" onClick={() => handleBudget(category.id, category.budget)}>
+                    Лимит
+                  </button>
+                  <button type="button" className={styles.danger} onClick={() => handleDelete(category.id)}>
+                    Удалить
+                  </button>
+                </div>
               </div>
-            </div>
-            <div className={styles.progressWrapper}>
-              <ProgressBar value={category.progress ?? 0} color={category.color ?? undefined} />
-              <div className={styles.progressText}>
-                {(category.spent ?? 0).toLocaleString('ru-RU')} ₽
-                {category.budget ? ` из ${category.budget.toLocaleString('ru-RU')} ₽` : ' • без лимита'}
-              </div>
-            </div>
-            <div className={styles.actions}>
-              <button type="button" onClick={() => handleRename(category.id, category.name)}>
-                Переименовать
-              </button>
-              <button type="button" onClick={() => handleBudget(category.id, category.budget)}>
-                Лимит
-              </button>
-              <button type="button" className={styles.danger} onClick={() => handleDelete(category.id)}>
-                Удалить
-              </button>
-            </div>
+            ))}
           </div>
-        ))}
-      </div>
+        ) : (
+          <p className={styles.placeholder}>Добавьте категории, чтобы следить за лимитами расходов.</p>
+        )}
+      </section>
+
+      {incomeCategories.length ? (
+        <section className={styles.section}>
+          <header className={styles.header}>
+            <span>Категории доходов</span>
+            <span className={styles.caption}>Поступления за выбранный месяц</span>
+          </header>
+          <div className={styles.list}>
+            {incomeCategories.map((category) => (
+              <div key={category.id} className={styles.item}>
+                <div className={styles.info}>
+                  <div className={styles.icon} style={{ background: category.color ?? '#272637' }} />
+                  <div>
+                    <div className={styles.name}>{category.name}</div>
+                    <div className={styles.meta}>Доход</div>
+                  </div>
+                </div>
+                <div className={styles.incomeWrapper}>
+                  <div className={styles.incomeValue}>
+                    {(category.earned ?? 0).toLocaleString('ru-RU')} ₽
+                  </div>
+                  <div className={styles.incomeMeta}>Получено за месяц</div>
+                </div>
+                <div className={styles.actions}>
+                  <button type="button" onClick={() => handleRename(category.id, category.name)}>
+                    Переименовать
+                  </button>
+                  <button type="button" onClick={() => handleBudget(category.id, category.budget)}>
+                    Лимит
+                  </button>
+                  <button type="button" className={styles.danger} onClick={() => handleDelete(category.id)}>
+                    Удалить
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+      ) : null}
+
       {error && <p className={styles.error}>{error}</p>}
     </div>
   );

--- a/components/PortfolioDividends.module.css
+++ b/components/PortfolioDividends.module.css
@@ -34,6 +34,11 @@
   padding: 0;
 }
 
+.chartWrapper {
+  width: 100%;
+  height: 280px;
+}
+
 .summaryItem {
   background: rgba(255, 255, 255, 0.04);
   border-radius: 16px;

--- a/components/PortfolioDividends.tsx
+++ b/components/PortfolioDividends.tsx
@@ -1,5 +1,6 @@
 import { format } from 'date-fns';
 import { ru } from 'date-fns/locale';
+import { Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 
 import styles from './PortfolioDividends.module.css';
 
@@ -25,12 +26,61 @@ interface Props {
 }
 
 export function PortfolioDividends({ dividends, summary }: Props) {
+  const chartData = summary
+    .map((item) => {
+      const date = new Date(`${item.month}-01T00:00:00.000Z`);
+      const shortLabel = format(date, 'LLL yy', { locale: ru }).replace('.', '');
+      return { ...item, shortLabel };
+    })
+    .sort((a, b) => (a.month > b.month ? 1 : -1));
+
   return (
     <div className={styles.container}>
       <div className={styles.header}>
         <h3 className={styles.title}>Дивиденды и выплаты</h3>
         <p className={styles.subtitle}>Фактические поступления по данным T-Bank Инвестиций</p>
       </div>
+
+      {chartData.length ? (
+        <div className={styles.chartWrapper}>
+          <ResponsiveContainer width="100%" height={280}>
+            <BarChart data={chartData}>
+              <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.06)" vertical={false} />
+              <XAxis
+                dataKey="shortLabel"
+                stroke="rgba(255, 255, 255, 0.5)"
+                tickLine={false}
+                axisLine={false}
+              />
+              <YAxis
+                stroke="rgba(255, 255, 255, 0.5)"
+                tickLine={false}
+                axisLine={false}
+                tickFormatter={(value: number) => value.toLocaleString('ru-RU')}
+              />
+              <Tooltip
+                contentStyle={{
+                  background: 'rgba(10, 8, 18, 0.95)',
+                  border: '1px solid rgba(255, 255, 255, 0.1)',
+                  borderRadius: 12,
+                }}
+                formatter={(value: number, _name, payload) => [
+                  `${value.toLocaleString('ru-RU', { minimumFractionDigits: 2 })} ${payload?.payload?.currency ?? ''}`,
+                  'Дивиденды',
+                ]}
+                labelFormatter={(label, payload) =>
+                  payload && payload[0]
+                    ? format(new Date(`${payload[0].payload.month}-01T00:00:00.000Z`), 'LLLL yyyy', {
+                        locale: ru,
+                      }).replace('.', '')
+                    : label
+                }
+              />
+              <Bar dataKey="total" radius={[10, 10, 0, 0]} fill="#38bdf8" />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      ) : null}
 
       <ul className={styles.summaryList}>
         {summary.map((item) => (

--- a/components/SpendingChart.module.css
+++ b/components/SpendingChart.module.css
@@ -21,5 +21,5 @@
 
 .chartWrapper {
   width: 100%;
-  height: 240px;
+  height: 320px;
 }

--- a/components/SpendingChart.tsx
+++ b/components/SpendingChart.tsx
@@ -1,10 +1,11 @@
-import { Area, AreaChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import { Area, AreaChart, CartesianGrid, Legend, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 
 import styles from './SpendingChart.module.css';
 
 interface DataPoint {
   date: string;
-  value: number;
+  income: number;
+  expenses: number;
 }
 
 interface Props {
@@ -20,17 +21,21 @@ export function SpendingChart({ data }: Props) {
     <div className={styles.container}>
       <header className={styles.header}>
         <div>
-          <h3>Ритм расходов</h3>
-          <p>На графике отражены траты по дням выбранного месяца</p>
+          <h3>Ритм доходов и расходов</h3>
+          <p>Сравните ежедневные поступления и траты выбранного месяца</p>
         </div>
       </header>
       <div className={styles.chartWrapper}>
-        <ResponsiveContainer width="100%" height={240}>
+        <ResponsiveContainer width="100%" height={320}>
           <AreaChart data={formatted} margin={{ left: 0, right: 0, top: 20, bottom: 0 }}>
             <defs>
-              <linearGradient id="colorSpend" x1="0" y1="0" x2="0" y2="1">
-                <stop offset="0%" stopColor="#f97316" stopOpacity={0.8} />
-                <stop offset="100%" stopColor="#f97316" stopOpacity={0} />
+              <linearGradient id="chart-expenses" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor="#ef4444" stopOpacity={0.8} />
+                <stop offset="100%" stopColor="#ef4444" stopOpacity={0} />
+              </linearGradient>
+              <linearGradient id="chart-income" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor="#22c55e" stopOpacity={0.8} />
+                <stop offset="100%" stopColor="#22c55e" stopOpacity={0} />
               </linearGradient>
             </defs>
             <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.06)" vertical={false} />
@@ -42,10 +47,32 @@ export function SpendingChart({ data }: Props) {
                 border: '1px solid rgba(255, 255, 255, 0.1)',
                 borderRadius: 12,
               }}
-              formatter={(value: number) => [`${value.toLocaleString('ru-RU')} ₽`, 'Расходы']}
+              formatter={(value: number, name: string) => {
+                const title = name === 'expenses' ? 'Расходы' : 'Доходы';
+                return [`${value.toLocaleString('ru-RU')} ₽`, title];
+              }}
               labelFormatter={(label) => `День ${label}`}
             />
-            <Area type="monotone" dataKey="value" stroke="#f97316" strokeWidth={2} fill="url(#colorSpend)" />
+            <Legend
+              wrapperStyle={{ paddingTop: 12 }}
+              formatter={(value) => (value === 'expenses' ? 'Расходы' : 'Доходы')}
+            />
+            <Area
+              type="monotone"
+              dataKey="expenses"
+              stroke="#ef4444"
+              strokeWidth={2}
+              fill="url(#chart-expenses)"
+              name="expenses"
+            />
+            <Area
+              type="monotone"
+              dataKey="income"
+              stroke="#22c55e"
+              strokeWidth={2}
+              fill="url(#chart-income)"
+              name="income"
+            />
           </AreaChart>
         </ResponsiveContainer>
       </div>

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -76,7 +76,11 @@ export default function Dashboard({ user }: DashboardProps) {
 
   const analytics = useSWR<AnalyticsResponse>(analyticsKey);
   const categories = useSWR<{ categories: Category[] }>(categoriesKey);
-  const expenses = useSWR<{ expenses: ExpenseItem[]; daily: Array<{ date: string; value: number }>; totals: { income: number; expenses: number } }>(
+  const expenses = useSWR<{
+    expenses: ExpenseItem[];
+    daily: Array<{ date: string; income: number; expenses: number }>;
+    totals: { income: number; expenses: number };
+  }>(
     expensesKey,
   );
 
@@ -156,8 +160,11 @@ export default function Dashboard({ user }: DashboardProps) {
         />
       </section>
 
-      <section className={styles.gridTwoColumn}>
+      <section className={styles.gridSingle}>
         <SpendingChart data={expenses.data?.daily ?? []} />
+      </section>
+
+      <section className={styles.gridSingle}>
         <BreakdownList items={analytics.data?.breakdown ?? []} />
       </section>
 


### PR DESCRIPTION
## Summary
- separate income and expense aggregation in categories and daily stats
- redesign spending chart to display daily income and expense flows full width
- add monthly dividend bar chart and adjust category list layout for clearer income tracking

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2baacf6488330896ad5ec105b5696