### PR TITLE
Add CSV/TSV import for bulk operations

### DIFF
--- a/components/ExpenseImport.module.css
+++ b/components/ExpenseImport.module.css
@@ -1,0 +1,103 @@
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 24px;
+  background: rgba(20, 18, 26, 0.85);
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: #fff;
+}
+
+.caption {
+  margin: 0;
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.modeToggle {
+  display: inline-flex;
+  gap: 12px;
+  background: rgba(10, 9, 15, 0.9);
+  border-radius: 999px;
+  padding: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  align-self: flex-start;
+}
+
+.modeOption {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.75);
+  cursor: pointer;
+}
+
+.modeOption input {
+  accent-color: #22d3ee;
+}
+
+.actions {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.uploadButton {
+  padding: 12px 20px;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, #22d3ee, #6366f1);
+  color: #04060f;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.uploadButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.hint {
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.error {
+  margin: 0;
+  color: #fb7185;
+  font-size: 13px;
+}
+
+.result {
+  margin: 0;
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.summary {
+  display: flex;
+  gap: 16px;
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.75);
+  flex-wrap: wrap;
+}
+
+.summary strong {
+  color: #fff;
+}

--- a/components/ExpenseImport.tsx
+++ b/components/ExpenseImport.tsx
@@ -1,0 +1,253 @@
+import { ChangeEvent, useMemo, useRef, useState } from 'react';
+
+import styles from './ExpenseImport.module.css';
+
+type Mode = 'EXPENSE' | 'INCOME';
+
+interface Props {
+  onImported: () => void;
+}
+
+interface ParsedOperation {
+  date: string;
+  categoryName: string | null;
+  amount: number;
+  description: string | null;
+}
+
+interface ImportResponse {
+  created: number;
+  skipped: number;
+  categoriesCreated: number;
+}
+
+interface ParseResult {
+  operations: ParsedOperation[];
+  skipped: number;
+}
+
+function normaliseHeader(value: string): string {
+  return value.replace(/^"|"$/g, '').trim().toLowerCase();
+}
+
+function detectDelimiter(headerLine: string): string {
+  if (headerLine.includes('\t')) return '\t';
+  if (headerLine.includes(';')) return ';';
+  return ',';
+}
+
+function parseAmount(raw: string): number | null {
+  const normalised = raw.replace(/[\s\u00a0]/g, '').replace(',', '.');
+  if (!normalised) return null;
+  const amount = Number(normalised);
+  if (!Number.isFinite(amount) || amount <= 0) {
+    return null;
+  }
+  return amount;
+}
+
+function parseDate(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  const parts = trimmed.split(/[./-]/).filter(Boolean);
+  if (parts.length < 3) return null;
+  const [dayStr, monthStr, yearStr] = parts;
+  const day = Number(dayStr);
+  const month = Number(monthStr);
+  let year = Number(yearStr);
+
+  if (!Number.isInteger(day) || !Number.isInteger(month)) {
+    return null;
+  }
+
+  if (yearStr.length === 2) {
+    year += year < 50 ? 2000 : 1900;
+  }
+
+  if (!Number.isInteger(year)) {
+    return null;
+  }
+
+  const date = new Date(Date.UTC(year, month - 1, day));
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  return date.toISOString().slice(0, 10);
+}
+
+function parseTable(content: string): ParseResult {
+  const lines = content
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  if (lines.length === 0) {
+    return { operations: [], skipped: 0 };
+  }
+
+  const delimiter = detectDelimiter(lines[0]);
+  const headerCells = lines[0].split(delimiter).map(normaliseHeader);
+
+  const dateIndex = headerCells.findIndex((cell) => cell.includes('дата'));
+  const categoryIndex = headerCells.findIndex((cell) => cell.includes('катег'));
+  const amountIndex = headerCells.findIndex((cell) => cell.includes('стоим') || cell.includes('сумм'));
+  const commentIndex = headerCells.findIndex((cell) => cell.includes('коммент') || cell.includes('опис'));
+
+  const operations: ParsedOperation[] = [];
+  let skipped = 0;
+
+  for (let i = 1; i < lines.length; i += 1) {
+    const cells = lines[i].split(delimiter).map((cell) => cell.replace(/^"|"$/g, '').trim());
+
+    const dateValue = dateIndex >= 0 ? cells[dateIndex] ?? '' : '';
+    const categoryValue = categoryIndex >= 0 ? cells[categoryIndex] ?? '' : '';
+    const amountValue = amountIndex >= 0 ? cells[amountIndex] ?? '' : '';
+    const commentValue = commentIndex >= 0 ? cells[commentIndex] ?? '' : '';
+
+    const amount = parseAmount(amountValue);
+    const date = parseDate(dateValue);
+
+    if (!amount || !date) {
+      skipped += 1;
+      continue;
+    }
+
+    operations.push({
+      amount,
+      date,
+      categoryName: categoryValue ? categoryValue.trim() : null,
+      description: commentValue ? commentValue.trim() : null,
+    });
+  }
+
+  return { operations, skipped };
+}
+
+export function ExpenseImport({ onImported }: Props) {
+  const [mode, setMode] = useState<Mode>('EXPENSE');
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [result, setResult] = useState<ImportResponse | null>(null);
+  const [localSkipped, setLocalSkipped] = useState(0);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const description = useMemo(() => {
+    if (mode === 'INCOME') {
+      return 'Загрузите CSV или TSV-файл с датой, категорией, суммой и комментарием — недостающие категории доходов создадутся автоматически.';
+    }
+    return 'Загрузите CSV или TSV-файл с датой, категорией, суммой и комментарием — мы импортируем траты и создадим категории, если их ещё нет.';
+  }, [mode]);
+
+  async function handleFileSelected(event: ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    setIsLoading(true);
+    setError('');
+    setResult(null);
+    setLocalSkipped(0);
+
+    try {
+      const text = await file.text();
+      const parsed = parseTable(text);
+      if (parsed.operations.length === 0) {
+        throw new Error('Не удалось найти операции в файле. Проверьте формат столбцов.');
+      }
+
+      setLocalSkipped(parsed.skipped);
+
+      const response = await fetch('/api/expenses/import', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ operations: parsed.operations, type: mode }),
+      });
+
+      if (!response.ok) {
+        const payload = await response.json().catch(() => ({}));
+        throw new Error(payload.message ?? 'Не удалось импортировать операции');
+      }
+
+      const payload = (await response.json()) as ImportResponse;
+      setResult(payload);
+      onImported();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Ошибка импорта');
+    } finally {
+      setIsLoading(false);
+      if (fileInputRef.current) {
+        fileInputRef.current.value = '';
+      }
+    }
+  }
+
+  return (
+    <div className={styles.card}>
+      <header className={styles.header}>
+        <h3 className={styles.title}>Импорт операций</h3>
+        <p className={styles.caption}>{description}</p>
+      </header>
+
+      <div className={styles.modeToggle}>
+        <label className={styles.modeOption}>
+          <input
+            type="radio"
+            name="import-mode"
+            value="EXPENSE"
+            checked={mode === 'EXPENSE'}
+            onChange={() => setMode('EXPENSE')}
+            disabled={isLoading}
+          />
+          Расходы
+        </label>
+        <label className={styles.modeOption}>
+          <input
+            type="radio"
+            name="import-mode"
+            value="INCOME"
+            checked={mode === 'INCOME'}
+            onChange={() => setMode('INCOME')}
+            disabled={isLoading}
+          />
+          Доходы
+        </label>
+      </div>
+
+      <div className={styles.actions}>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept=".csv,.tsv,.txt"
+          style={{ display: 'none' }}
+          onChange={handleFileSelected}
+          disabled={isLoading}
+        />
+        <button
+          type="button"
+          className={styles.uploadButton}
+          onClick={() => fileInputRef.current?.click()}
+          disabled={isLoading}
+        >
+          {isLoading ? 'Импортирую…' : 'Выбрать файл'}
+        </button>
+        <span className={styles.hint}>Требуются столбцы «Дата», «Категория», «Стоимость», «Комментарий».</span>
+      </div>
+
+      {error && <p className={styles.error}>{error}</p>}
+
+      {result && (
+        <div className={styles.summary}>
+          <span>
+            Импортировано: <strong>{result.created}</strong>
+          </span>
+          <span>
+            Создано категорий: <strong>{result.categoriesCreated}</strong>
+          </span>
+          <span>
+            Пропущено: <strong>{result.skipped + localSkipped}</strong>
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/pages/api/expenses/import.ts
+++ b/pages/api/expenses/import.ts
@@ -1,0 +1,162 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { CategoryType } from '@prisma/client';
+
+import { prisma } from '@/lib/prisma';
+import { requireAuth } from '@/lib/auth';
+
+interface OperationInput {
+  amount: number;
+  categoryName: string | null;
+  description: string | null;
+  date: string;
+}
+
+function normalizeCategoryName(name: string): string {
+  return name.trim().replace(/\s+/g, ' ');
+}
+
+const palette = ['#f97316', '#4f46e5', '#22d3ee', '#ff6b6b', '#39d98a', '#facc15', '#a855f7'];
+
+function pickColor(index: number): string {
+  return palette[index % palette.length];
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).json({ message: 'Method not allowed' });
+  }
+
+  const userId = requireAuth(req, res);
+  if (!userId) return;
+
+  const { operations, type } = req.body ?? {};
+
+  if (type !== 'EXPENSE' && type !== 'INCOME') {
+    return res.status(400).json({ message: 'Некорректный тип операций' });
+  }
+
+  if (!Array.isArray(operations) || operations.length === 0) {
+    return res.status(400).json({ message: 'Список операций пуст' });
+  }
+
+  const categoryType = type === 'INCOME' ? CategoryType.INCOME : CategoryType.EXPENSE;
+
+  const prepared: Array<{
+    amount: number;
+    date: Date;
+    categoryName: string | null;
+    description: string | null;
+  }> = [];
+  let skipped = 0;
+
+  for (const op of operations as OperationInput[]) {
+    const amount = Number(op?.amount);
+    if (!Number.isFinite(amount) || amount <= 0) {
+      skipped += 1;
+      continue;
+    }
+
+    const parsedDate = op?.date ? new Date(op.date) : null;
+    if (!parsedDate || Number.isNaN(parsedDate.getTime())) {
+      skipped += 1;
+      continue;
+    }
+
+    const description = typeof op?.description === 'string' && op.description.trim().length > 0 ? op.description.trim() : null;
+    const categoryName = typeof op?.categoryName === 'string' && op.categoryName.trim().length > 0 ? normalizeCategoryName(op.categoryName) : null;
+
+    if (type === 'INCOME' && !categoryName) {
+      skipped += 1;
+      continue;
+    }
+
+    prepared.push({ amount, date: parsedDate, categoryName, description });
+  }
+
+  if (prepared.length === 0) {
+    return res.status(400).json({ message: 'Не осталось валидных операций для импорта', skipped });
+  }
+
+  const existingCategories = await prisma.category.findMany({
+    where: {
+      userId,
+      type: categoryType,
+    },
+  });
+
+  const categoryMap = new Map<string, { id: string }>();
+  existingCategories.forEach((category) => {
+    categoryMap.set(normalizeCategoryName(category.name).toLowerCase(), { id: category.id });
+  });
+
+  const categoriesToCreate: string[] = [];
+  const categoriesToCreateKeys = new Set<string>();
+  prepared.forEach((item) => {
+    if (!item.categoryName) return;
+    const key = normalizeCategoryName(item.categoryName).toLowerCase();
+    if (!categoryMap.has(key) && !categoriesToCreateKeys.has(key)) {
+      categoriesToCreate.push(item.categoryName);
+      categoriesToCreateKeys.add(key);
+    }
+  });
+
+  const createdCategories: string[] = [];
+
+  for (let i = 0; i < categoriesToCreate.length; i += 1) {
+    const name = categoriesToCreate[i];
+    const category = await prisma.category.create({
+      data: {
+        name,
+        type: categoryType,
+        userId,
+        color: pickColor(i + existingCategories.length),
+      },
+    });
+    categoryMap.set(normalizeCategoryName(name).toLowerCase(), { id: category.id });
+    createdCategories.push(category.id);
+  }
+
+  let createdOperations = 0;
+
+  for (const item of prepared) {
+    let categoryId: string | null = null;
+    if (item.categoryName) {
+      const key = normalizeCategoryName(item.categoryName).toLowerCase();
+      const category = categoryMap.get(key);
+      if (!category) {
+        // Это может произойти только при гонке. Создадим категорию на лету.
+        const created = await prisma.category.create({
+          data: {
+            name: item.categoryName,
+            type: categoryType,
+            userId,
+            color: pickColor(createdCategories.length + existingCategories.length),
+          },
+        });
+        categoryMap.set(key, { id: created.id });
+        createdCategories.push(created.id);
+        categoryId = created.id;
+      } else {
+        categoryId = category.id;
+      }
+    }
+
+    await prisma.expense.create({
+      data: {
+        amount: item.amount,
+        categoryId,
+        description: item.description,
+        date: item.date,
+        userId,
+      },
+    });
+    createdOperations += 1;
+  }
+
+  return res.status(201).json({
+    created: createdOperations,
+    categoriesCreated: createdCategories.length,
+    skipped,
+  });
+}

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -10,6 +10,7 @@ import { DashboardLayout } from '@/components/DashboardLayout';
 import { MetricCard } from '@/components/MetricCard';
 import { SpendingChart } from '@/components/SpendingChart';
 import { ExpenseForm } from '@/components/ExpenseForm';
+import { ExpenseImport } from '@/components/ExpenseImport';
 import { ExpenseTable } from '@/components/ExpenseTable';
 import { CategoryForm } from '@/components/CategoryForm';
 import { CategoryList } from '@/components/CategoryList';
@@ -185,6 +186,10 @@ export default function Dashboard({ user }: DashboardProps) {
           allowUncategorized={false}
           onCreated={handleOperationsChanged}
         />
+      </section>
+
+      <section className={styles.gridSingle}>
+        <ExpenseImport onImported={handleOperationsChanged} />
       </section>
 
       <section className={styles.gridSingle}>


### PR DESCRIPTION
## Summary
- add a dashboard widget to import CSV/TSV tables and push them to the API as income or expense batches
- implement a server endpoint that creates missing categories and stores operations in one request
- style the import widget to match the existing dashboard cards

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2bf3bbf7c8330b067fc5c4d3ba7f6