### PR TITLE
Fix expenses API response mapping and include period range

### DIFF
--- a/pages/api/expenses/index.ts
+++ b/pages/api/expenses/index.ts
@@ -139,12 +139,14 @@ async function listExpenses(req: NextApiRequest, res: NextApiResponse) {
   }
 
   return res.status(200).json({
-    expenses: operations.map((item) => ({
+    expenses: expenses.map((item) => ({
       ...item,
       amount: Number(item.amount),
     })),
     totals,
     monthly,
+    periodStart: formatISO(start, { representation: 'date' }),
+    periodEnd: formatISO(end, { representation: 'date' }),
   });
 }
 


### PR DESCRIPTION
## Summary
- fix the expenses listing endpoint to return the fetched expenses instead of an undefined variable
- expose the start and end of the resolved period in the expenses API response for clients that need the range

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2f9087a98833098f9980a657459d8