### PR TITLE
Normalize expenses data before response

### DIFF
--- a/pages/api/expenses/index.ts
+++ b/pages/api/expenses/index.ts
@@ -58,7 +58,7 @@ async function listExpenses(req: NextApiRequest, res: NextApiResponse) {
     typeof req.query.end === 'string' ? req.query.end : undefined,
   );
 
-  const [expenses, timelineExpenses] = await Promise.all([
+  const [rawExpenses, timelineExpenses] = await Promise.all([
     prisma.expense.findMany({
       where: {
         userId,
@@ -84,7 +84,7 @@ async function listExpenses(req: NextApiRequest, res: NextApiResponse) {
     expenses: 0,
   };
 
-  expenses.forEach((expense) => {
+  rawExpenses.forEach((expense) => {
     if (expense.category?.type === 'INCOME') {
       totals.income += Number(expense.amount);
     } else {
@@ -138,13 +138,17 @@ async function listExpenses(req: NextApiRequest, res: NextApiResponse) {
     });
   }
 
+  const expenses = rawExpenses.map((item) => ({
+    ...item,
+    amount: Number(item.amount),
+  }));
+
   return res.status(200).json({
-    expenses: operations.map((item) => ({
-      ...item,
-      amount: Number(item.amount),
-    })),
+    expenses,
     totals,
     monthly,
+    periodStart: formatISO(start, { representation: 'date' }),
+    periodEnd: formatISO(end, { representation: 'date' }),
   });
 }
 


### PR DESCRIPTION
## Summary
- ensure the expenses query results are stored in a dedicated variable before formatting the response
- normalise expense amounts once and reuse the mapped array in the response payload

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e2f9087a98833098f9980a657459d8