### PR TITLE
Add timeframe presets to dashboard and update spending chart

### DIFF
--- a/components/SpendingChart.tsx
+++ b/components/SpendingChart.tsx
@@ -1,6 +1,16 @@
 import { format } from 'date-fns';
 import { ru } from 'date-fns/locale';
-import { Area, AreaChart, CartesianGrid, Legend, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
+import {
+  Area,
+  AreaChart,
+  Brush,
+  CartesianGrid,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
 
 import styles from './SpendingChart.module.css';
 
@@ -15,16 +25,26 @@ interface Props {
 }
 
 export function SpendingChart({ data }: Props) {
-  const formatted = [...data]
-    .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
-    .map((point) => {
-      const parsed = new Date(point.date);
-      const label = format(parsed, 'd MMMM yyyy', { locale: ru });
-      return {
-        ...point,
-        label: label.charAt(0).toUpperCase() + label.slice(1),
-      };
-    });
+  const sorted = [...data].sort(
+    (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
+  );
+
+  const firstMeaningfulIndex = sorted.findIndex(
+    (point) => point.income !== 0 || point.expenses !== 0,
+  );
+
+  const prepared =
+    firstMeaningfulIndex > 0 ? sorted.slice(firstMeaningfulIndex) : sorted;
+
+  const formatted = prepared.map((point) => {
+    const parsed = new Date(point.date);
+    const labelRaw = format(parsed, 'LLLL yyyy', { locale: ru });
+    const label = labelRaw.charAt(0).toUpperCase() + labelRaw.slice(1);
+    return {
+      ...point,
+      label,
+    };
+  });
 
   return (
     <div className={styles.container}>
@@ -48,8 +68,21 @@ export function SpendingChart({ data }: Props) {
               </linearGradient>
             </defs>
             <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.06)" vertical={false} />
-            <XAxis dataKey="label" stroke="rgba(255,255,255,0.5)" tickLine={false} axisLine={false} />
+            <XAxis
+              dataKey="label"
+              stroke="rgba(255,255,255,0.5)"
+              tickLine={false}
+              axisLine={false}
+              minTickGap={16}
+            />
             <YAxis stroke="rgba(255,255,255,0.5)" tickLine={false} axisLine={false} width={60} />
+            <Brush
+              dataKey="label"
+              height={28}
+              stroke="rgba(255, 255, 255, 0.3)"
+              travellerWidth={10}
+              fill="rgba(255, 255, 255, 0.04)"
+            />
             <Tooltip
               contentStyle={{
                 background: 'rgba(10, 8, 18, 0.95)',

--- a/styles/Dashboard.module.css
+++ b/styles/Dashboard.module.css
@@ -15,32 +15,70 @@
   color: rgba(255, 255, 255, 0.6);
 }
 
-.periodPickerGroup {
+.timeframeControls {
   display: flex;
   gap: 12px;
   flex-wrap: wrap;
   justify-content: flex-end;
+  align-items: center;
 }
 
-.periodPicker {
+.timeframeGroup {
   display: flex;
-  flex-direction: column;
   gap: 8px;
-  font-size: 14px;
-  color: rgba(255, 255, 255, 0.7);
-}
-
-.periodPicker input[type='month'] {
-  background: rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.06);
+  padding: 4px;
   border-radius: 12px;
-  border: none;
-  color: #fff;
-  padding: 12px 16px;
-  font-weight: 600;
 }
 
-.periodPicker input[type='month']::-webkit-calendar-picker-indicator {
-  filter: invert(1);
+.timeframeButton {
+  background: transparent;
+  border: none;
+  color: rgba(255, 255, 255, 0.65);
+  font-size: 13px;
+  padding: 6px 10px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.timeframeButton:hover {
+  color: #fff;
+}
+
+.timeframeButtonActive {
+  background: rgba(56, 189, 248, 0.16);
+  color: #fff;
+}
+
+.navigator {
+  display: flex;
+  gap: 8px;
+}
+
+.navigatorButton {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 10px;
+  color: #fff;
+  width: 36px;
+  height: 32px;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  font-size: 18px;
+  line-height: 1;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.navigatorButton:hover {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.navigatorButton:disabled {
+  opacity: 0.4;
+  cursor: default;
+  background: rgba(255, 255, 255, 0.06);
 }
 
 .metricsGrid {
@@ -70,7 +108,7 @@
     align-items: flex-start;
   }
 
-  .periodPickerGroup {
+  .timeframeControls {
     width: 100%;
     justify-content: flex-start;
   }


### PR DESCRIPTION
## Summary
- replace manual month pickers with timeframe presets and navigation in the dashboard header
- format the spending chart axis with month/year labels and add a brush for interactive zooming
- refresh dashboard styles to support the new controls

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e303b1f5988330b3e8117783baa984