### PR TITLE
Add AI-driven cashflow simulator

### DIFF
--- a/components/DashboardLayout.tsx
+++ b/components/DashboardLayout.tsx
@@ -24,6 +24,9 @@ export function DashboardLayout({ user, onLogout, children }: Props) {
           <Link href="/portfolio" className={styles.navItem}>
             Инвестиции
           </Link>
+          <Link href="/cashflow" className={styles.navItem}>
+            Cashflow
+          </Link>
         </nav>
         <div className={styles.userCard}>
           <div className={styles.avatar}>{user.name.slice(0, 1).toUpperCase()}</div>

--- a/components/cashflow/CashflowGame.module.css
+++ b/components/cashflow/CashflowGame.module.css
@@ -1,0 +1,379 @@
+.container {
+  min-height: 100vh;
+  padding: 3rem clamp(1.5rem, 4vw, 4rem) 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.header {
+  max-width: 720px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.title {
+  font-size: clamp(2rem, 4vw, 3rem);
+  font-weight: 700;
+  margin: 0;
+}
+
+.subtitle {
+  margin: 0;
+  color: rgba(248, 244, 255, 0.72);
+  line-height: 1.5;
+  font-size: 1.05rem;
+}
+
+.selectorGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+}
+
+.professionCard {
+  border-radius: 20px;
+  background: linear-gradient(135deg, rgba(54, 47, 93, 0.6), rgba(29, 26, 45, 0.9));
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  cursor: pointer;
+}
+
+.professionCard:hover {
+  transform: translateY(-6px);
+  border-color: rgba(255, 198, 109, 0.45);
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.35);
+}
+
+.professionName {
+  font-size: 1.3rem;
+  font-weight: 600;
+}
+
+.professionMeta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.95rem;
+  color: rgba(248, 244, 255, 0.75);
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.65rem;
+  border-radius: 999px;
+  background: rgba(239, 168, 63, 0.18);
+  color: #fbd49c;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.boardLayout {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(12, 1fr);
+}
+
+.column {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.leftColumn {
+  grid-column: span 3;
+}
+
+.centerColumn {
+  grid-column: span 6;
+}
+
+.rightColumn {
+  grid-column: span 3;
+}
+
+.section {
+  padding: 1.5rem;
+  background: rgba(20, 17, 33, 0.75);
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.sectionTitle {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.listItem {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.95rem;
+  color: rgba(248, 244, 255, 0.85);
+}
+
+.listItemLabel {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.passivePill {
+  background: rgba(104, 214, 171, 0.18);
+  color: #8bf0c6;
+  border-radius: 999px;
+  padding: 0.1rem 0.55rem;
+  font-size: 0.7rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.listItem strong {
+  font-weight: 600;
+  color: #f8f4ff;
+}
+
+.negative {
+  color: #f28b91;
+}
+
+.itemDetails {
+  display: block;
+  margin-top: 0.3rem;
+  font-size: 0.78rem;
+  color: rgba(248, 244, 255, 0.6);
+}
+
+.balanceSummary {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.balanceRow {
+  display: flex;
+  justify-content: space-between;
+  color: rgba(248, 244, 255, 0.75);
+  font-size: 0.95rem;
+}
+
+.balanceRow strong {
+  color: #f8f4ff;
+  font-weight: 600;
+}
+
+.eventCard {
+  display: grid;
+  gap: 1.5rem;
+  background: linear-gradient(135deg, rgba(59, 52, 101, 0.45), rgba(17, 15, 29, 0.95));
+  border-radius: 24px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 1.75rem;
+  box-shadow: 0 24px 45px rgba(0, 0, 0, 0.35);
+}
+
+.eventHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.eventTitle {
+  font-size: 1.4rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.eventNarrative {
+  margin: 0;
+  line-height: 1.55;
+  color: rgba(248, 244, 255, 0.78);
+}
+
+.eventStats {
+  display: grid;
+  gap: 0.85rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.statBox {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 18px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.statLabel {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(248, 244, 255, 0.55);
+}
+
+.statValue {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1rem;
+}
+
+.rangeInput {
+  flex: 1;
+  accent-color: #f0a85b;
+}
+
+.numberInput {
+  width: 110px;
+  padding: 0.6rem 0.75rem;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(12, 11, 16, 0.9);
+  color: #f8f4ff;
+  font-size: 1rem;
+}
+
+.primaryButton,
+.secondaryButton {
+  border: none;
+  border-radius: 14px;
+  padding: 0.75rem 1.4rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.primaryButton {
+  background: linear-gradient(135deg, #f0a85b, #e26597);
+  color: #150d1f;
+  box-shadow: 0 16px 30px rgba(226, 101, 151, 0.25);
+}
+
+.primaryButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.secondaryButton {
+  background: rgba(255, 255, 255, 0.08);
+  color: #f8f4ff;
+}
+
+.primaryButton:hover:not(:disabled),
+.secondaryButton:hover {
+  transform: translateY(-2px);
+}
+
+.advisor {
+  background: rgba(36, 28, 52, 0.85);
+  border-radius: 18px;
+  padding: 1.25rem;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  display: grid;
+  gap: 0.5rem;
+}
+
+.advisorLabel {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(248, 244, 255, 0.55);
+}
+
+.advisorMessage {
+  margin: 0;
+  line-height: 1.5;
+  color: rgba(248, 244, 255, 0.85);
+}
+
+.progressCard {
+  display: grid;
+  gap: 1rem;
+}
+
+.progressRow {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.progressHeader {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.9rem;
+  color: rgba(248, 244, 255, 0.72);
+}
+
+.logList {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-height: 380px;
+  overflow-y: auto;
+}
+
+.logItem {
+  display: grid;
+  gap: 0.35rem;
+  padding: 0.85rem 1rem;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 16px;
+}
+
+.logMonth {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(248, 244, 255, 0.55);
+}
+
+@media (max-width: 1200px) {
+  .boardLayout {
+    grid-template-columns: repeat(6, 1fr);
+  }
+
+  .leftColumn,
+  .rightColumn {
+    grid-column: span 6;
+  }
+
+  .centerColumn {
+    grid-column: span 6;
+  }
+}
+
+@media (max-width: 768px) {
+  .container {
+    padding: 2.5rem 1.5rem 3rem;
+  }
+
+  .boardLayout {
+    display: flex;
+    flex-direction: column;
+  }
+}

--- a/components/cashflow/CashflowGame.tsx
+++ b/components/cashflow/CashflowGame.tsx
@@ -1,0 +1,1114 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import { ProgressBar } from '@/components/ProgressBar';
+
+import { professions } from './constants';
+import type {
+  Asset,
+  BusinessOpportunity,
+  GameEvent,
+  GameState,
+  IncomeItem,
+  LifeEvent,
+  RealEstateOpportunity,
+  StockOpportunity,
+  WindfallEvent,
+} from './types';
+import styles from './CashflowGame.module.css';
+
+const currencyFormatter = new Intl.NumberFormat('ru-RU', {
+  style: 'currency',
+  currency: 'RUB',
+  maximumFractionDigits: 0,
+});
+
+const formatCurrency = (value: number) => currencyFormatter.format(Math.round(value));
+
+const createId = () => Math.random().toString(36).slice(2, 10);
+
+const sumIncome = (incomes: IncomeItem[]) => incomes.reduce((total, income) => total + income.amount, 0);
+const sumAssetsValue = (assets: Asset[]) => assets.reduce((total, asset) => total + asset.value, 0);
+const sumLiabilities = (liabilities: GameState['liabilities']) =>
+  liabilities.reduce((total, liability) => total + liability.balance, 0);
+const sumExpenses = (expenses: GameState['expenses']) => expenses.reduce((total, expense) => total + expense.amount, 0);
+
+const calculatePassiveIncome = (incomes: IncomeItem[]) =>
+  incomes.filter((income) => income.type === 'PASSIVE').reduce((total, income) => total + income.amount, 0);
+
+const calculateNetWorth = (state: GameState) => state.cash + sumAssetsValue(state.assets) - sumLiabilities(state.liabilities);
+
+const randomBetween = ([min, max]: [number, number]) => min + Math.random() * (max - min);
+
+const pickRandom = <T,>(items: T[]): T => items[Math.floor(Math.random() * items.length)];
+
+type StockAction = { type: 'BUY_STOCK'; quantity: number } | { type: 'SKIP_STOCK' };
+type RealEstateAction = { type: 'BUY_PROPERTY' } | { type: 'SKIP_PROPERTY' };
+type BusinessAction = { type: 'BUY_BUSINESS' } | { type: 'SKIP_BUSINESS' };
+type LifeAction = { type: 'ACKNOWLEDGE' };
+type WindfallAction = { type: 'ACCEPT_WINDFALL' };
+
+type GameAction = StockAction | RealEstateAction | BusinessAction | LifeAction | WindfallAction;
+
+interface ApplyResult {
+  state: GameState;
+  summary: string;
+}
+
+const stockCatalog: Array<
+  Omit<StockOpportunity, 'id' | 'price' | 'fairValue' | 'expectedDividend' | 'maxShares' | 'narrative'> & {
+    price: [number, number];
+    fairValue: [number, number];
+    expectedDividend: [number, number];
+    maxShares: [number, number];
+    narrative: (event: StockOpportunity) => string;
+  }
+> = [
+  {
+    type: 'STOCK',
+    company: 'АгроСбыт',
+    sector: 'аграрный сектор',
+    price: [18, 28],
+    fairValue: [20, 34],
+    expectedDividend: [0.6, 1.2],
+    maxShares: [30, 160],
+    narrative: (event) =>
+      `Вы замечаете отчёт «${event.company}»: ${event.sector} ускоряется на фоне экспортных контрактов. Бумага торгуется по ${formatCurrency(
+        event.price,
+      )}, справедливая цена оценена в ${formatCurrency(event.fairValue)}. Компания платит дивиденды ${formatCurrency(
+        event.expectedDividend,
+      )} на акцию.`,
+  },
+  {
+    type: 'STOCK',
+    company: 'СеверПоток Логистикс',
+    sector: 'логистика и контейнерные перевозки',
+    price: [42, 68],
+    fairValue: [48, 82],
+    expectedDividend: [1.1, 2],
+    maxShares: [20, 110],
+    narrative: (event) =>
+      `«${event.company}» расширяет сервис последней мили. Акции стоят ${formatCurrency(
+        event.price,
+      )}, аналитики считают справедливой стоимость ${formatCurrency(event.fairValue)}. Дивиденды составляют около ${formatCurrency(
+        event.expectedDividend,
+      )} на акцию в месяц.`,
+  },
+  {
+    type: 'STOCK',
+    company: 'НеонКод',
+    sector: 'разработка корпоративного софта',
+    price: [65, 110],
+    fairValue: [72, 135],
+    expectedDividend: [0.4, 1.4],
+    maxShares: [10, 80],
+    narrative: (event) =>
+      `«${event.company}» выходит на рынки Ближнего Востока. Бумаги стоят ${formatCurrency(
+        event.price,
+      )}, справедливая цена оценивается в ${formatCurrency(event.fairValue)}. Менеджмент обещает buyback и дивиденды ${formatCurrency(
+        event.expectedDividend,
+      )}.`,
+  },
+];
+
+const realEstateCatalog: Array<
+  Omit<RealEstateOpportunity, 'id' | 'narrative'> & { narrative: (event: RealEstateOpportunity) => string }
+> = [
+  {
+    type: 'REAL_ESTATE',
+    propertyType: 'Апартаменты у набережной',
+    price: 4_800_000,
+    downPayment: 480_000,
+    monthlyRent: 58_000,
+    monthlyExpenses: 34_000,
+    appreciation: 6,
+    narrative: (event) =>
+      `На вторичном рынке появляются ${event.propertyType.toLowerCase()} с полной отделкой. Продавец готов уступить при быстрой сделке, ожидаемый рост цен — ${event.appreciation}% в год.`,
+  },
+  {
+    type: 'REAL_ESTATE',
+    propertyType: 'Студия в коворкинге',
+    price: 3_100_000,
+    downPayment: 310_000,
+    monthlyRent: 42_000,
+    monthlyExpenses: 24_000,
+    appreciation: 4,
+    narrative: (event) =>
+      `Развивающийся район предлагает ${event.propertyType.toLowerCase()} с действующим арендатором. Управляющая компания берёт фиксированную ставку, прогноз роста стоимости — ${event.appreciation}% в год.`,
+  },
+  {
+    type: 'REAL_ESTATE',
+    propertyType: 'Склад-кроссдокинг',
+    price: 6_200_000,
+    downPayment: 620_000,
+    monthlyRent: 74_000,
+    monthlyExpenses: 46_000,
+    appreciation: 5,
+    narrative: (event) =>
+      `Логистический парк предлагает ${event.propertyType.toLowerCase()} вблизи нового шоссе. Подписан договор на 11 месяцев, прогноз роста аренды — ${event.appreciation}% ежегодно.`,
+  },
+];
+
+const businessCatalog: Array<
+  Omit<BusinessOpportunity, 'id' | 'narrative'> & { narrative: (event: BusinessOpportunity) => string }
+> = [
+  {
+    type: 'BUSINESS',
+    business: 'Франшиза кофе-поинта',
+    buyInCost: 280_000,
+    monthlyProfit: 22_000,
+    effortLevel: 'средняя',
+    narrative: (event) =>
+      `Франчайзер предлагает ${event.business.toLowerCase()} в бизнес-центре. Требуется ${event.effortLevel} вовлечённость: 2-3 визита в неделю и контроль персонала.`,
+  },
+  {
+    type: 'BUSINESS',
+    business: 'Онлайн-курс по аналитике',
+    buyInCost: 190_000,
+    monthlyProfit: 18_000,
+    effortLevel: 'низкая',
+    narrative: (event) =>
+      `Авторская команда ищет партнёра для продвижения. ${event.business} готов, нужно поддерживать трафик и продажи.`,
+  },
+  {
+    type: 'BUSINESS',
+    business: 'Мобильная автомойка',
+    buyInCost: 350_000,
+    monthlyProfit: 30_000,
+    effortLevel: 'высокая',
+    narrative: (event) =>
+      `Партнёры предлагают долю в проекте «${event.business}». Потребуется ${event.effortLevel} вовлечённость: поиск парковок и найм сотрудников.`,
+  },
+];
+
+const lifeEventsCatalog: Array<
+  Omit<LifeEvent, 'id' | 'narrative'> & { narrative: (event: LifeEvent) => string }
+> = [
+  {
+    type: 'LIFE',
+    label: 'Рождение ребёнка',
+    amount: 18_500,
+    category: 'expense_increase',
+    narrative: () => 'В семью приходит новый член, и ваш ежемесячный бюджет пополняется расходами на подгузники, одежду и кружки.',
+  },
+  {
+    type: 'LIFE',
+    label: 'Премия за проект',
+    amount: 12_000,
+    category: 'income_increase',
+    narrative: () => 'Компания оценила ваши идеи и повышает ежемесячный оклад. Важно решить, пустить ли прибавку в потребление или в инвестиции.',
+  },
+  {
+    type: 'LIFE',
+    label: 'Закрытие кредита',
+    amount: -8_000,
+    category: 'expense_decrease',
+    narrative: () => 'Вы закрываете один из кредитов досрочно. Бюджет освобождает часть ежемесячных платежей.',
+  },
+];
+
+const windfallCatalog: Array<
+  Omit<WindfallEvent, 'id' | 'narrative'> & { narrative: (event: WindfallEvent) => string }
+> = [
+  {
+    type: 'WINDFALL',
+    amount: 55_000,
+    source: 'возврат налога за инвестиционный вычет',
+    narrative: (event) => `На счёт поступает ${formatCurrency(event.amount)} — ${event.source}. Можно направить в подушку безопасности или инвестиции.`,
+  },
+  {
+    type: 'WINDFALL',
+    amount: 24_000,
+    source: 'кэшбэк по корпоративной карте',
+    narrative: (event) => `Банк начисляет ${formatCurrency(event.amount)} кэшбэка. Это шанс ускорить достижение цели или закрыть часть долга.`,
+  },
+  {
+    type: 'WINDFALL',
+    amount: 80_000,
+    source: 'продажа старой машины',
+    narrative: (event) => `Вы продаёте авто и получаете ${formatCurrency(event.amount)}. Решите, распределить ли сумму между долгами и инвестициями.`,
+  },
+];
+
+const createStockEvent = (): StockOpportunity => {
+  const template = pickRandom(stockCatalog);
+  const price = Math.round(randomBetween(template.price));
+  const fairValue = Math.round(randomBetween(template.fairValue));
+  const expectedDividend = Math.round(randomBetween(template.expectedDividend) * 100) / 100;
+  const maxShares = Math.round(randomBetween(template.maxShares));
+  const event: StockOpportunity = {
+    id: createId(),
+    type: 'STOCK',
+    company: template.company,
+    sector: template.sector,
+    price,
+    fairValue,
+    expectedDividend,
+    maxShares: Math.max(maxShares, 5),
+    narrative: '',
+  };
+  event.narrative = template.narrative(event);
+  return event;
+};
+
+const createRealEstateEvent = (): RealEstateOpportunity => {
+  const template = pickRandom(realEstateCatalog);
+  const event: RealEstateOpportunity = {
+    ...template,
+    id: createId(),
+    narrative: template.narrative(template),
+  };
+  return event;
+};
+
+const createBusinessEvent = (): BusinessOpportunity => {
+  const template = pickRandom(businessCatalog);
+  const event: BusinessOpportunity = {
+    ...template,
+    id: createId(),
+    narrative: template.narrative(template),
+  };
+  return event;
+};
+
+const createLifeEvent = (): LifeEvent => {
+  const template = pickRandom(lifeEventsCatalog);
+  const event: LifeEvent = {
+    ...template,
+    id: createId(),
+    narrative: template.narrative(template),
+  };
+  return event;
+};
+
+const createWindfallEvent = (): WindfallEvent => {
+  const template = pickRandom(windfallCatalog);
+  const event: WindfallEvent = {
+    ...template,
+    id: createId(),
+    narrative: template.narrative(template),
+  };
+  return event;
+};
+
+const generateEvent = (state: GameState): GameEvent => {
+  const roll = Math.random();
+  const passiveShare = calculatePassiveIncome(state.incomes) / Math.max(sumIncome(state.incomes), 1);
+
+  if (roll < 0.28) {
+    return createStockEvent();
+  }
+
+  if (roll < 0.52) {
+    return createRealEstateEvent();
+  }
+
+  if (roll < 0.72) {
+    return createBusinessEvent();
+  }
+
+  if (roll < 0.9) {
+    // Если пассивный доход уже высокий, чаще предлагаем жизненные изменения
+    if (passiveShare > 0.35 && Math.random() < 0.5) {
+      return createLifeEvent();
+    }
+    return createWindfallEvent();
+  }
+
+  return createLifeEvent();
+};
+
+const getAdvisorSuggestion = (state: GameState, event: GameEvent) => {
+  const totalIncome = sumIncome(state.incomes);
+  const totalExpenses = sumExpenses(state.expenses);
+  const cashFlow = totalIncome - totalExpenses;
+  const passiveIncome = calculatePassiveIncome(state.incomes);
+  const reserveMonths = totalExpenses > 0 ? state.cash / totalExpenses : Infinity;
+  const netWorth = calculateNetWorth(state);
+
+  switch (event.type) {
+    case 'STOCK': {
+      const discount = ((event.fairValue - event.price) / event.fairValue) * 100;
+      if (reserveMonths < 2) {
+        return `Запас прочности ${reserveMonths.toFixed(1)} мес. Перед покупкой акций стоит усилить подушку безопасности.`;
+      }
+      if (discount > 8) {
+        return `Акция торгуется со скидкой ${discount.toFixed(1)}%. Можно купить часть, но оставьте кеш на новые идеи.`;
+      }
+      if (cashFlow < 0) {
+        return 'Текущий денежный поток отрицательный. Имеет смысл сначала стабилизировать бюджет.';
+      }
+      return 'Инвестируйте аккуратно: разделите покупку на несколько месяцев и отслеживайте отчётность компании.';
+    }
+    case 'REAL_ESTATE': {
+      if (state.cash < event.downPayment) {
+        return 'Нужно накопить первоначальный взнос — подумайте о временной цели накопления.';
+      }
+      const netCashflow = event.monthlyRent - event.monthlyExpenses;
+      if (netCashflow > 0 && reserveMonths >= 3) {
+        return `Арендный поток ${formatCurrency(netCashflow)} в месяц увеличит пассивный доход до ${formatCurrency(
+          passiveIncome + netCashflow,
+        )}. Проверьте, готовы ли к управлению.`;
+      }
+      return 'Сделка на грани безубыточности. Взвесьте, готовы ли к рискам простоя и дополнительным расходам.';
+    }
+    case 'BUSINESS': {
+      if (state.cash < event.buyInCost) {
+        return 'Для входа не хватает капитала — оцените возможность привлечь партнёра или подождать лучшую сделку.';
+      }
+      if (event.effortLevel === 'высокая') {
+        return 'Потребуется серьёзная вовлечённость. Подумайте, есть ли свободное время без ущерба основной работе.';
+      }
+      if (reserveMonths >= 3 && cashFlow > 0) {
+        return `Потенциальный поток ${formatCurrency(event.monthlyProfit)}. Зафиксируйте KPI и автоматизируйте операционные задачи.`;
+      }
+      return 'Вложение выглядит интересно, но убедитесь, что текущий денежный поток выдержит просадку в первые месяцы.';
+    }
+    case 'LIFE': {
+      if (event.category === 'expense_increase') {
+        return 'Новый расход. Проверьте страховку, автоматизируйте накопления и пересоберите бюджет.';
+      }
+      if (event.category === 'income_increase') {
+        return 'Направьте прибавку на ускорение целей: пополните резерв или увеличьте долю инвестиций.';
+      }
+      return 'Освободившийся расход можно направить на досрочное погашение других долгов или инвестиции.';
+    }
+    case 'WINDFALL': {
+      if (cashFlow < 0) {
+        return 'Используйте внезапный доход, чтобы закрыть дефицит бюджета и нарастить подушку.';
+      }
+      if (netWorth < state.profession.goalNetWorth / 2) {
+        return 'Распределите сумму: часть в резерв, часть в инвестиции с умеренным риском.';
+      }
+      return 'Можно направить большую долю в инвестпортфель, но оставьте немного на гибкость и удовольствие.';
+    }
+    default:
+      return '';
+  }
+};
+
+const applyStockAction = (state: GameState, event: StockOpportunity, action: StockAction): ApplyResult => {
+  if (action.type === 'SKIP_STOCK') {
+    return { state, summary: `Вы пропустили возможность с акцией «${event.company}».` };
+  }
+
+  const cost = event.price * action.quantity;
+  const dividendIncome = event.expectedDividend * action.quantity;
+
+  if (action.quantity <= 0 || cost > state.cash) {
+    return { state, summary: 'Сделка не состоялась: недостаточно средств.' };
+  }
+
+  const assetId = createId();
+  const incomeId = createId();
+
+  const updatedState: GameState = {
+    ...state,
+    cash: state.cash - cost,
+    assets: [
+      ...state.assets,
+      {
+        id: assetId,
+        name: `${event.company}`,
+        type: 'STOCK',
+        value: cost,
+        cashflow: dividendIncome,
+        details: `${action.quantity} шт. по ${formatCurrency(event.price)}`,
+        incomeId,
+      },
+    ],
+    incomes: [
+      ...state.incomes,
+      {
+        id: incomeId,
+        label: `Дивиденды ${event.company}`,
+        amount: dividendIncome,
+        type: 'PASSIVE',
+      },
+    ],
+  };
+
+  const summary = `Куплено ${action.quantity} шт. «${event.company}» за ${formatCurrency(cost)}. Ожидаемый пассивный доход ${formatCurrency(
+    dividendIncome,
+  )} в месяц.`;
+
+  return { state: updatedState, summary };
+};
+
+const applyRealEstateAction = (
+  state: GameState,
+  event: RealEstateOpportunity,
+  action: RealEstateAction,
+): ApplyResult => {
+  if (action.type === 'SKIP_PROPERTY') {
+    return { state, summary: `Вы пропустили объект «${event.propertyType}».` };
+  }
+
+  if (state.cash < event.downPayment) {
+    return { state, summary: 'Недостаточно средств для первоначального взноса.' };
+  }
+
+  const assetId = createId();
+  const incomeId = createId();
+  const expenseId = createId();
+  const liabilityId = createId();
+
+  const updatedState: GameState = {
+    ...state,
+    cash: state.cash - event.downPayment,
+    assets: [
+      ...state.assets,
+      {
+        id: assetId,
+        name: event.propertyType,
+        type: 'REAL_ESTATE',
+        value: event.price,
+        cashflow: event.monthlyRent - event.monthlyExpenses,
+        details: `Взнос ${formatCurrency(event.downPayment)}, аренда ${formatCurrency(event.monthlyRent)}`,
+        incomeId,
+      },
+    ],
+    incomes: [
+      ...state.incomes,
+      {
+        id: incomeId,
+        label: `Аренда: ${event.propertyType}`,
+        amount: event.monthlyRent,
+        type: 'PASSIVE',
+      },
+    ],
+    expenses: [
+      ...state.expenses,
+      {
+        id: expenseId,
+        label: `Обслуживание: ${event.propertyType}`,
+        amount: event.monthlyExpenses,
+      },
+    ],
+    liabilities: [
+      ...state.liabilities,
+      {
+        id: liabilityId,
+        name: `Ипотека: ${event.propertyType}`,
+        balance: Math.max(event.price - event.downPayment, 0),
+        payment: event.monthlyExpenses,
+      },
+    ],
+  };
+
+  const netCashflow = event.monthlyRent - event.monthlyExpenses;
+  const summary = `Вы вложились в ${event.propertyType}. Чистый поток ${formatCurrency(netCashflow)} в месяц после обслуживания.`;
+
+  return { state: updatedState, summary };
+};
+
+const applyBusinessAction = (state: GameState, event: BusinessOpportunity, action: BusinessAction): ApplyResult => {
+  if (action.type === 'SKIP_BUSINESS') {
+    return { state, summary: `Вы решили не входить в «${event.business}».` };
+  }
+
+  if (state.cash < event.buyInCost) {
+    return { state, summary: 'Для покупки доли не хватает средств.' };
+  }
+
+  const assetId = createId();
+  const incomeId = createId();
+
+  const updatedState: GameState = {
+    ...state,
+    cash: state.cash - event.buyInCost,
+    assets: [
+      ...state.assets,
+      {
+        id: assetId,
+        name: event.business,
+        type: 'BUSINESS',
+        value: event.buyInCost,
+        cashflow: event.monthlyProfit,
+        details: `Доля с ${event.effortLevel} вовлечённостью`,
+        incomeId,
+      },
+    ],
+    incomes: [
+      ...state.incomes,
+      {
+        id: incomeId,
+        label: `Поток: ${event.business}`,
+        amount: event.monthlyProfit,
+        type: 'PASSIVE',
+      },
+    ],
+  };
+
+  const summary = `Вы инвестировали в ${event.business} за ${formatCurrency(event.buyInCost)}. Поток ${formatCurrency(
+    event.monthlyProfit,
+  )} в месяц.`;
+
+  return { state: updatedState, summary };
+};
+
+const applyLifeAction = (state: GameState, event: LifeEvent): ApplyResult => {
+  if (event.category === 'income_increase') {
+    const incomeId = createId();
+    const updatedState: GameState = {
+      ...state,
+      incomes: [
+        ...state.incomes,
+        {
+          id: incomeId,
+          label: event.label,
+          amount: event.amount,
+          type: 'ACTIVE',
+        },
+      ],
+    };
+    return { state: updatedState, summary: `Доход увеличился: ${event.label} на ${formatCurrency(event.amount)}.` };
+  }
+
+  const expenseId = createId();
+  const updatedState: GameState = {
+    ...state,
+    expenses: [
+      ...state.expenses,
+      {
+        id: expenseId,
+        label: event.label,
+        amount: event.amount,
+      },
+    ],
+  };
+
+  const change = event.amount >= 0 ? 'увеличились' : 'сократились';
+  return { state: updatedState, summary: `Расходы ${change} на ${formatCurrency(Math.abs(event.amount))}.` };
+};
+
+const applyWindfallAction = (state: GameState, event: WindfallEvent): ApplyResult => {
+  const updatedState: GameState = {
+    ...state,
+    cash: state.cash + event.amount,
+  };
+  return { state: updatedState, summary: `Получен внезапный доход ${formatCurrency(event.amount)} (${event.source}).` };
+};
+
+const applyEventAction = (state: GameState, event: GameEvent, action: GameAction): ApplyResult => {
+  switch (event.type) {
+    case 'STOCK':
+      return applyStockAction(state, event, action as StockAction);
+    case 'REAL_ESTATE':
+      return applyRealEstateAction(state, event, action as RealEstateAction);
+    case 'BUSINESS':
+      return applyBusinessAction(state, event, action as BusinessAction);
+    case 'LIFE':
+      return applyLifeAction(state, event);
+    case 'WINDFALL':
+      return applyWindfallAction(state, event);
+    default:
+      return { state, summary: '' };
+  }
+};
+
+const advanceMonth = (state: GameState, summary: string): GameState => {
+  const totalIncome = sumIncome(state.incomes);
+  const totalExpenses = sumExpenses(state.expenses);
+  const cashFlow = totalIncome - totalExpenses;
+  const nextCash = state.cash + cashFlow;
+  const nextState: GameState = {
+    ...state,
+    cash: nextCash,
+    month: state.month + 1,
+    log: [
+      {
+        id: createId(),
+        month: state.month,
+        message: `${summary} Денежный поток месяца: ${formatCurrency(cashFlow)}. Баланс ${formatCurrency(
+          nextCash,
+        )}. Капитал ${formatCurrency(calculateNetWorth({ ...state, cash: nextCash }))}.`,
+      },
+      ...state.log,
+    ].slice(0, 12),
+  };
+  return nextState;
+};
+
+const createInitialState = (professionId: string): GameState => {
+  const profession = professions.find((item) => item.id === professionId) ?? professions[0];
+  const incomeId = createId();
+  return {
+    profession,
+    month: 1,
+    cash: profession.startingCash,
+    incomes: [
+      {
+        id: incomeId,
+        label: 'Зарплата',
+        amount: profession.salary,
+        type: 'ACTIVE',
+      },
+    ],
+    expenses: profession.expenses.map((expense) => ({ ...expense })),
+    assets: [],
+    liabilities: [],
+    log: [
+      {
+        id: createId(),
+        month: 0,
+        message: `Вы выбрали профессию «${profession.name}». Стартовый капитал ${formatCurrency(
+          profession.startingCash,
+        )}. Цель — капитал ${formatCurrency(profession.goalNetWorth)} и пассивный доход ${formatCurrency(
+          profession.goalPassiveIncome,
+        )}.`,
+      },
+    ],
+  };
+};
+
+export function CashflowGame() {
+  const [gameState, setGameState] = useState<GameState | null>(null);
+  const [currentEvent, setCurrentEvent] = useState<GameEvent | null>(null);
+  const [advisorMessage, setAdvisorMessage] = useState('');
+  const [stockQuantity, setStockQuantity] = useState(0);
+
+  useEffect(() => {
+    setStockQuantity(0);
+  }, [currentEvent?.id]);
+
+  const handleStart = (professionId: string) => {
+    const initialState = createInitialState(professionId);
+    const event = generateEvent(initialState);
+    setGameState(initialState);
+    setCurrentEvent(event);
+    setAdvisorMessage(getAdvisorSuggestion(initialState, event));
+  };
+
+  const handleAction = (action: GameAction) => {
+    if (!gameState || !currentEvent) return;
+
+    const { state: afterEvent, summary } = applyEventAction(gameState, currentEvent, action);
+    const advancedState = advanceMonth(afterEvent, summary);
+    const nextEvent = generateEvent(advancedState);
+
+    setGameState(advancedState);
+    setCurrentEvent(nextEvent);
+    setAdvisorMessage(getAdvisorSuggestion(advancedState, nextEvent));
+  };
+
+  const derived = useMemo(() => {
+    if (!gameState) {
+      return null;
+    }
+
+    const totalIncome = sumIncome(gameState.incomes);
+    const totalExpenses = sumExpenses(gameState.expenses);
+    const passiveIncome = calculatePassiveIncome(gameState.incomes);
+    const cashFlow = totalIncome - totalExpenses;
+    const netWorth = calculateNetWorth(gameState);
+    const reserveMonths = totalExpenses > 0 ? gameState.cash / totalExpenses : Infinity;
+
+    return {
+      totalIncome,
+      totalExpenses,
+      passiveIncome,
+      cashFlow,
+      netWorth,
+      reserveMonths,
+      incomeList: gameState.incomes,
+      expenseList: gameState.expenses,
+      assets: gameState.assets,
+      liabilities: gameState.liabilities,
+    };
+  }, [gameState]);
+
+  if (!gameState || !currentEvent || !derived) {
+    return (
+      <div className={styles.container}>
+        <div className={styles.header}>
+          <h1 className={styles.title}>Cashflow тренажёр с ИИ-наставником</h1>
+          <p className={styles.subtitle}>
+            Выберите профессию и проживите 5–7 лет финансовых решений в ускоренном темпе. Каждый месяц вас ждут рыночные
+            события, жизненные повороты и советы виртуального наставника.
+          </p>
+        </div>
+        <div className={styles.selectorGrid}>
+          {professions.map((profession) => (
+            <button
+              type="button"
+              key={profession.id}
+              className={styles.professionCard}
+              onClick={() => handleStart(profession.id)}
+            >
+              <div>
+                <div className={styles.professionName}>{profession.name}</div>
+                <p className={styles.professionMeta}>{profession.description}</p>
+              </div>
+              <div className={styles.professionMeta}>
+                <span className={styles.tag}>Зарплата {formatCurrency(profession.salary)}</span>
+                <span className={styles.tag}>Капитал {formatCurrency(profession.goalNetWorth)}</span>
+                <span className={styles.tag}>Пассивный поток {formatCurrency(profession.goalPassiveIncome)}</span>
+              </div>
+            </button>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  const { totalIncome, totalExpenses, passiveIncome, cashFlow, netWorth, reserveMonths } = derived;
+  const goalNetWorth = gameState.profession.goalNetWorth;
+  const goalPassiveIncome = gameState.profession.goalPassiveIncome;
+  const netWorthProgress = Math.min(netWorth / goalNetWorth, 1);
+  const passiveProgress = Math.min(passiveIncome / goalPassiveIncome, 1);
+
+  const renderEventControls = () => {
+    switch (currentEvent.type) {
+      case 'STOCK': {
+        const maxAffordableShares = Math.min(
+          currentEvent.maxShares,
+          Math.floor(gameState.cash / currentEvent.price),
+        );
+        const safeQuantity = Math.min(stockQuantity, maxAffordableShares);
+        const totalCost = currentEvent.price * safeQuantity;
+        const expectedIncome = currentEvent.expectedDividend * safeQuantity;
+        const discount = ((currentEvent.fairValue - currentEvent.price) / currentEvent.fairValue) * 100;
+        return (
+          <>
+            <div className={styles.eventStats}>
+              <div className={styles.statBox}>
+                <span className={styles.statLabel}>Цена</span>
+                <span className={styles.statValue}>{formatCurrency(currentEvent.price)}</span>
+              </div>
+              <div className={styles.statBox}>
+                <span className={styles.statLabel}>Справедливая</span>
+                <span className={styles.statValue}>{formatCurrency(currentEvent.fairValue)}</span>
+              </div>
+              <div className={styles.statBox}>
+                <span className={styles.statLabel}>Дивиденды/акция</span>
+                <span className={styles.statValue}>{formatCurrency(currentEvent.expectedDividend)}</span>
+              </div>
+              <div className={styles.statBox}>
+                <span className={styles.statLabel}>Дисконт</span>
+                <span className={styles.statValue}>{`${discount.toFixed(1)}%`}</span>
+              </div>
+            </div>
+            <div className={styles.controls}>
+              <input
+                type="range"
+                min={0}
+                max={Math.max(maxAffordableShares, 0)}
+                value={safeQuantity}
+                step={1}
+                onChange={(event) => setStockQuantity(Math.max(0, Math.floor(Number(event.target.value))))}
+                className={styles.rangeInput}
+              />
+              <input
+                type="number"
+                min={0}
+                max={Math.max(maxAffordableShares, 0)}
+                step={1}
+                value={safeQuantity}
+                onChange={(event) => setStockQuantity(Math.max(0, Math.floor(Number(event.target.value))))}
+                className={styles.numberInput}
+              />
+              <button
+                type="button"
+                className={styles.primaryButton}
+                disabled={safeQuantity <= 0 || totalCost > gameState.cash}
+                onClick={() => handleAction({ type: 'BUY_STOCK', quantity: safeQuantity })}
+              >
+                Купить на {formatCurrency(totalCost)}
+              </button>
+              <button
+                type="button"
+                className={styles.secondaryButton}
+                onClick={() => handleAction({ type: 'SKIP_STOCK' })}
+              >
+                Пропустить
+              </button>
+            </div>
+            <div className={styles.balanceSummary}>
+              <div className={styles.balanceRow}>
+                <span>Ожидаемый поток</span>
+                <strong>{formatCurrency(expectedIncome)}</strong>
+              </div>
+              <div className={styles.balanceRow}>
+                <span>Доступно средств</span>
+                <strong>{formatCurrency(gameState.cash - totalCost)}</strong>
+              </div>
+            </div>
+          </>
+        );
+      }
+      case 'REAL_ESTATE': {
+        const netCashflow = currentEvent.monthlyRent - currentEvent.monthlyExpenses;
+        const canAfford = gameState.cash >= currentEvent.downPayment;
+        return (
+          <>
+            <div className={styles.eventStats}>
+              <div className={styles.statBox}>
+                <span className={styles.statLabel}>Стоимость</span>
+                <span className={styles.statValue}>{formatCurrency(currentEvent.price)}</span>
+              </div>
+              <div className={styles.statBox}>
+                <span className={styles.statLabel}>Первоначальный взнос</span>
+                <span className={styles.statValue}>{formatCurrency(currentEvent.downPayment)}</span>
+              </div>
+              <div className={styles.statBox}>
+                <span className={styles.statLabel}>Аренда</span>
+                <span className={styles.statValue}>{formatCurrency(currentEvent.monthlyRent)}</span>
+              </div>
+              <div className={styles.statBox}>
+                <span className={styles.statLabel}>Платежи</span>
+                <span className={styles.statValue}>{formatCurrency(currentEvent.monthlyExpenses)}</span>
+              </div>
+            </div>
+            <div className={styles.controls}>
+              <button
+                type="button"
+                className={styles.primaryButton}
+                disabled={!canAfford}
+                onClick={() => handleAction({ type: 'BUY_PROPERTY' })}
+              >
+                Купить объект
+              </button>
+              <button
+                type="button"
+                className={styles.secondaryButton}
+                onClick={() => handleAction({ type: 'SKIP_PROPERTY' })}
+              >
+                Пропустить
+              </button>
+            </div>
+            <div className={styles.balanceSummary}>
+              <div className={styles.balanceRow}>
+                <span>Чистый поток</span>
+                <strong>{formatCurrency(netCashflow)}</strong>
+              </div>
+              <div className={styles.balanceRow}>
+                <span>Останется наличных</span>
+                <strong>{formatCurrency(gameState.cash - currentEvent.downPayment)}</strong>
+              </div>
+            </div>
+          </>
+        );
+      }
+      case 'BUSINESS': {
+        return (
+          <>
+            <div className={styles.eventStats}>
+              <div className={styles.statBox}>
+                <span className={styles.statLabel}>Стоимость входа</span>
+                <span className={styles.statValue}>{formatCurrency(currentEvent.buyInCost)}</span>
+              </div>
+              <div className={styles.statBox}>
+                <span className={styles.statLabel}>Потенциал</span>
+                <span className={styles.statValue}>{formatCurrency(currentEvent.monthlyProfit)}</span>
+              </div>
+              <div className={styles.statBox}>
+                <span className={styles.statLabel}>Вовлечённость</span>
+                <span className={styles.statValue}>{currentEvent.effortLevel}</span>
+              </div>
+            </div>
+            <div className={styles.controls}>
+              <button
+                type="button"
+                className={styles.primaryButton}
+                disabled={gameState.cash < currentEvent.buyInCost}
+                onClick={() => handleAction({ type: 'BUY_BUSINESS' })}
+              >
+                Инвестировать
+              </button>
+              <button
+                type="button"
+                className={styles.secondaryButton}
+                onClick={() => handleAction({ type: 'SKIP_BUSINESS' })}
+              >
+                Пропустить
+              </button>
+            </div>
+          </>
+        );
+      }
+      case 'LIFE': {
+        return (
+          <>
+            <div className={styles.eventStats}>
+              <div className={styles.statBox}>
+                <span className={styles.statLabel}>Изменение</span>
+                <span className={styles.statValue}>
+                  {currentEvent.amount >= 0 ? '+' : ''}
+                  {formatCurrency(currentEvent.amount)}
+                </span>
+              </div>
+            </div>
+            <div className={styles.controls}>
+              <button type="button" className={styles.primaryButton} onClick={() => handleAction({ type: 'ACKNOWLEDGE' })}>
+                Продолжить
+              </button>
+            </div>
+          </>
+        );
+      }
+      case 'WINDFALL': {
+        return (
+          <>
+            <div className={styles.eventStats}>
+              <div className={styles.statBox}>
+                <span className={styles.statLabel}>Сумма</span>
+                <span className={styles.statValue}>{formatCurrency(currentEvent.amount)}</span>
+              </div>
+              <div className={styles.statBox}>
+                <span className={styles.statLabel}>Источник</span>
+                <span className={styles.statValue}>{currentEvent.source}</span>
+              </div>
+            </div>
+            <div className={styles.controls}>
+              <button type="button" className={styles.primaryButton} onClick={() => handleAction({ type: 'ACCEPT_WINDFALL' })}>
+                Принять
+              </button>
+            </div>
+          </>
+        );
+      }
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.boardLayout}>
+        <div className={`${styles.column} ${styles.leftColumn}`}>
+          <div className={styles.section}>
+            <h2 className={styles.sectionTitle}>Доходы</h2>
+            <ul className={styles.list}>
+              {derived.incomeList.map((income) => (
+                <li key={income.id} className={styles.listItem}>
+                  <span className={styles.listItemLabel}>
+                    {income.label}
+                    {income.type === 'PASSIVE' && <span className={styles.passivePill}>пассивно</span>}
+                  </span>
+                  <strong>{formatCurrency(income.amount)}</strong>
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div className={styles.section}>
+            <h2 className={styles.sectionTitle}>Расходы</h2>
+            <ul className={styles.list}>
+              {derived.expenseList.map((expense) => (
+                <li key={expense.id} className={styles.listItem}>
+                  <span>{expense.label}</span>
+                  <strong className={expense.amount < 0 ? styles.negative : undefined}>
+                    {formatCurrency(expense.amount)}
+                  </strong>
+                </li>
+              ))}
+            </ul>
+          </div>
+          {derived.assets.length > 0 && (
+            <div className={styles.section}>
+              <h2 className={styles.sectionTitle}>Активы</h2>
+              <ul className={styles.list}>
+                {derived.assets.map((asset) => (
+                  <li key={asset.id} className={styles.listItem}>
+                    <span>
+                      {asset.name}
+                      <span className={styles.itemDetails}>{asset.details}</span>
+                    </span>
+                    <strong>{formatCurrency(asset.value)}</strong>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {derived.liabilities.length > 0 && (
+            <div className={styles.section}>
+              <h2 className={styles.sectionTitle}>Пассивы</h2>
+              <ul className={styles.list}>
+                {derived.liabilities.map((liability) => (
+                  <li key={liability.id} className={styles.listItem}>
+                    <span>
+                      {liability.name}
+                      <span className={styles.itemDetails}>Остаток {formatCurrency(liability.balance)}</span>
+                    </span>
+                    <strong>{formatCurrency(liability.payment)}</strong>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+        <div className={`${styles.column} ${styles.centerColumn}`}>
+          <div className={styles.eventCard}>
+            <div className={styles.eventHeader}>
+              <span className={styles.tag}>Месяц {gameState.month}</span>
+              <h2 className={styles.eventTitle}>
+                {currentEvent.type === 'STOCK' && `Фондовый рынок: ${currentEvent.company}`}
+                {currentEvent.type === 'REAL_ESTATE' && `Недвижимость: ${currentEvent.propertyType}`}
+                {currentEvent.type === 'BUSINESS' && `Бизнес: ${currentEvent.business}`}
+                {currentEvent.type === 'LIFE' && currentEvent.label}
+                {currentEvent.type === 'WINDFALL' && 'Внезапный доход'}
+              </h2>
+              <p className={styles.eventNarrative}>{currentEvent.narrative}</p>
+            </div>
+            {renderEventControls()}
+          </div>
+          <div className={styles.advisor}>
+            <span className={styles.advisorLabel}>Совет ИИ-наставника</span>
+            <p className={styles.advisorMessage}>{advisorMessage}</p>
+          </div>
+        </div>
+        <div className={`${styles.column} ${styles.rightColumn}`}>
+          <div className={`${styles.section} ${styles.progressCard}`}>
+            <h2 className={styles.sectionTitle}>Прогресс</h2>
+            <div className={styles.progressRow}>
+              <div className={styles.progressHeader}>
+                <span>Капитал {formatCurrency(netWorth)}</span>
+                <span>Цель {formatCurrency(goalNetWorth)}</span>
+              </div>
+              <ProgressBar value={netWorthProgress} />
+            </div>
+            <div className={styles.progressRow}>
+              <div className={styles.progressHeader}>
+                <span>Пассивный доход {formatCurrency(passiveIncome)}</span>
+                <span>Цель {formatCurrency(goalPassiveIncome)}</span>
+              </div>
+              <ProgressBar value={passiveProgress} />
+            </div>
+            <div className={styles.balanceSummary}>
+              <div className={styles.balanceRow}>
+                <span>Всего доходов</span>
+                <strong>{formatCurrency(totalIncome)}</strong>
+              </div>
+              <div className={styles.balanceRow}>
+                <span>Всего расходов</span>
+                <strong>{formatCurrency(totalExpenses)}</strong>
+              </div>
+              <div className={styles.balanceRow}>
+                <span>Денежный поток</span>
+                <strong>{formatCurrency(cashFlow)}</strong>
+              </div>
+              <div className={styles.balanceRow}>
+                <span>Свободные средства</span>
+                <strong>{formatCurrency(gameState.cash)}</strong>
+              </div>
+              <div className={styles.balanceRow}>
+                <span>Финансовая подушка</span>
+                <strong>{reserveMonths === Infinity ? '∞' : `${reserveMonths.toFixed(1)} мес.`}</strong>
+              </div>
+            </div>
+          </div>
+          <div className={styles.section}>
+            <h2 className={styles.sectionTitle}>Журнал решений</h2>
+            <div className={styles.logList}>
+              {gameState.log.map((entry) => (
+                <div key={entry.id} className={styles.logItem}>
+                  <span className={styles.logMonth}>Месяц {entry.month}</span>
+                  <span>{entry.message}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/cashflow/constants.ts
+++ b/components/cashflow/constants.ts
@@ -1,0 +1,78 @@
+import { Profession } from './types';
+
+const createExpense = (label: string, amount: number, id: string) => ({ id, label, amount });
+
+export const professions: Profession[] = [
+  {
+    id: 'developer',
+    name: 'Продуктовый аналитик',
+    salary: 185_000,
+    description:
+      'Работает в крупной технологической компании, получает опционы и заботится о карьерном росте. Ищет баланс между комфортом и инвестициями.',
+    startingCash: 160_000,
+    goalNetWorth: 900_000,
+    goalPassiveIncome: 95_000,
+    expenses: [
+      createExpense('Ипотека', 48_000, 'mortgage'),
+      createExpense('Кредит за авто', 14_500, 'car-loan'),
+      createExpense('Еда и бытовые расходы', 28_000, 'living'),
+      createExpense('Образование и саморазвитие', 10_000, 'education'),
+      createExpense('Развлечения и путешествия', 12_000, 'lifestyle'),
+      createExpense('Налоги и страхование', 9_500, 'insurance'),
+    ],
+  },
+  {
+    id: 'teacher',
+    name: 'Преподаватель экономики',
+    salary: 95_000,
+    description:
+      'Ведёт курсы по финансовой грамотности и подрабатывает репетитором. Цель — накопить капитал для открытия онлайн-школы.',
+    startingCash: 70_000,
+    goalNetWorth: 600_000,
+    goalPassiveIncome: 55_000,
+    expenses: [
+      createExpense('Аренда квартиры', 32_000, 'rent'),
+      createExpense('Транспорт и связь', 8_500, 'transport'),
+      createExpense('Продукты и быт', 22_000, 'groceries'),
+      createExpense('Кредиты', 6_000, 'loans'),
+      createExpense('Развлечения', 6_500, 'fun'),
+      createExpense('Дети и образование', 11_000, 'kids'),
+    ],
+  },
+  {
+    id: 'doctor',
+    name: 'Врач-реаниматолог',
+    salary: 140_000,
+    description:
+      'Чередует смены в частной и государственной клиниках, поэтому доход нестабилен. Хочет создать подушку безопасности и вложиться в недвижимость.',
+    startingCash: 110_000,
+    goalNetWorth: 750_000,
+    goalPassiveIncome: 70_000,
+    expenses: [
+      createExpense('Ипотека', 38_000, 'mortgage'),
+      createExpense('Обслуживание кредита на обучение', 9_500, 'student-loan'),
+      createExpense('Расходы на семью', 24_000, 'family'),
+      createExpense('Транспорт', 7_500, 'transport'),
+      createExpense('Продукты и досуг', 21_000, 'groceries'),
+      createExpense('Страхование', 8_000, 'insurance'),
+    ],
+  },
+  {
+    id: 'designer',
+    name: 'Фриланс-дизайнер',
+    salary: 120_000,
+    description:
+      'Занимается digital-продуктами и берёт проекты на зарубежных заказчиков. Основной вызов — колебания дохода и высокий налог на самозанятость.',
+    startingCash: 95_000,
+    goalNetWorth: 680_000,
+    goalPassiveIncome: 60_000,
+    expenses: [
+      createExpense('Аренда студии и жилья', 45_000, 'rent'),
+      createExpense('Налоги и взносы', 18_000, 'taxes'),
+      createExpense('Техника и подписки', 12_500, 'gear'),
+      createExpense('Продукты', 19_000, 'food'),
+      createExpense('Путешествия и вдохновение', 15_000, 'travel'),
+      createExpense('Образование', 6_500, 'education'),
+    ],
+  },
+];

--- a/components/cashflow/types.ts
+++ b/components/cashflow/types.ts
@@ -1,0 +1,114 @@
+export type IncomeType = 'ACTIVE' | 'PASSIVE';
+
+export interface IncomeItem {
+  id: string;
+  label: string;
+  amount: number;
+  type: IncomeType;
+}
+
+export interface ExpenseItem {
+  id: string;
+  label: string;
+  amount: number;
+}
+
+export type AssetType = 'STOCK' | 'REAL_ESTATE' | 'BUSINESS';
+
+export interface Asset {
+  id: string;
+  name: string;
+  type: AssetType;
+  value: number;
+  cashflow: number;
+  details: string;
+  incomeId?: string;
+}
+
+export interface Liability {
+  id: string;
+  name: string;
+  balance: number;
+  payment: number;
+}
+
+export interface Profession {
+  id: string;
+  name: string;
+  salary: number;
+  description: string;
+  startingCash: number;
+  goalNetWorth: number;
+  goalPassiveIncome: number;
+  expenses: ExpenseItem[];
+}
+
+export interface GameLogEntry {
+  id: string;
+  month: number;
+  message: string;
+}
+
+export interface GameState {
+  profession: Profession;
+  month: number;
+  cash: number;
+  incomes: IncomeItem[];
+  expenses: ExpenseItem[];
+  assets: Asset[];
+  liabilities: Liability[];
+  log: GameLogEntry[];
+}
+
+interface BaseEvent {
+  id: string;
+  narrative: string;
+}
+
+export interface StockOpportunity extends BaseEvent {
+  type: 'STOCK';
+  company: string;
+  sector: string;
+  price: number;
+  fairValue: number;
+  expectedDividend: number;
+  maxShares: number;
+}
+
+export interface RealEstateOpportunity extends BaseEvent {
+  type: 'REAL_ESTATE';
+  propertyType: string;
+  price: number;
+  downPayment: number;
+  monthlyRent: number;
+  monthlyExpenses: number;
+  appreciation: number;
+}
+
+export interface BusinessOpportunity extends BaseEvent {
+  type: 'BUSINESS';
+  business: string;
+  buyInCost: number;
+  monthlyProfit: number;
+  effortLevel: 'низкая' | 'средняя' | 'высокая';
+}
+
+export interface LifeEvent extends BaseEvent {
+  type: 'LIFE';
+  label: string;
+  amount: number;
+  category: 'expense_increase' | 'expense_decrease' | 'income_increase';
+}
+
+export interface WindfallEvent extends BaseEvent {
+  type: 'WINDFALL';
+  amount: number;
+  source: string;
+}
+
+export type GameEvent =
+  | StockOpportunity
+  | RealEstateOpportunity
+  | BusinessOpportunity
+  | LifeEvent
+  | WindfallEvent;

--- a/pages/cashflow.tsx
+++ b/pages/cashflow.tsx
@@ -1,0 +1,18 @@
+import Head from 'next/head';
+
+import { CashflowGame } from '@/components/cashflow/CashflowGame';
+
+export default function CashflowPage() {
+  return (
+    <>
+      <Head>
+        <title>Cashflow тренажёр — Finly Autopilot</title>
+        <meta
+          name="description"
+          content="Интерактивный тренажёр по финансовой грамотности на основе игры Денежный поток Роберта Кийосаки, дополненный советами ИИ-наставника."
+        />
+      </Head>
+      <CashflowGame />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add a cashflow training game with profession setup, procedural events, and AI-style guidance
- style the new simulator view with responsive panels for income, assets, and event handling
- expose the experience on /cashflow and link it from the sidebar navigation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e441efbfa48330abe28cb46ba55647