### PR TITLE
Use Tinkoff CDN logos for portfolio positions

### DIFF
--- a/components/PortfolioPositions.module.css
+++ b/components/PortfolioPositions.module.css
@@ -40,6 +40,36 @@
   font-size: 14px;
 }
 
+.instrumentCell {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.instrumentLogo {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.06);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  color: #fff;
+  font-weight: 600;
+  font-size: 14px;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.instrumentLogo img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
 .badge {
   display: inline-flex;
   align-items: center;

--- a/lib/tbank.ts
+++ b/lib/tbank.ts
@@ -141,6 +141,10 @@ type GetCandlesResponse = {
   candles?: ApiHistoricCandle[] | null;
 };
 
+type InstrumentBrand = {
+  logoName?: string | null;
+};
+
 type Instrument = {
   figi?: string | null;
   ticker?: string | null;
@@ -148,6 +152,7 @@ type Instrument = {
   instrumentType?: string | null;
   lot?: number | string | null;
   currency?: string | null;
+  brand?: InstrumentBrand | null;
 };
 
 type InstrumentResponse = {
@@ -195,6 +200,7 @@ type InstrumentMeta = {
   instrumentType?: string;
   lot?: number | null;
   currency?: string | null;
+  brandLogoName?: string | null;
 };
 
 type PortfolioSnapshotPoint = {
@@ -607,6 +613,7 @@ async function enrichInstrumentMetadata(
       instrumentType: position.instrumentType ?? undefined,
       lot: position.lot ?? undefined,
       currency: position.currency ?? undefined,
+      brandLogoName: undefined,
     });
   });
 
@@ -644,6 +651,7 @@ async function enrichInstrumentMetadata(
           instrumentType: instrument.instrumentType ?? existing?.instrumentType ?? undefined,
           lot: parseNumber(instrument.lot),
           currency: instrument.currency ?? existing?.currency ?? undefined,
+          brandLogoName: instrument.brand?.logoName ?? existing?.brandLogoName ?? undefined,
         });
       }
     } catch (error) {
@@ -831,6 +839,7 @@ export async function syncTinkoffPortfolio(connectionId: string) {
       expectedYieldPercent: roundNumber(expectedYieldPercent),
       currentPrice: roundNumber(currentPriceValue),
       currency: position.currency ?? meta?.currency ?? null,
+      brandLogoName: meta?.brandLogoName ?? null,
     };
   });
 

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,15 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'invest-brands.cdn-tinkoff.ru',
+        pathname: '/**',
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/pages/api/invest/portfolio.ts
+++ b/pages/api/invest/portfolio.ts
@@ -71,6 +71,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       investedAmount: Math.round(invested * 100) / 100,
       currentValue: Math.round(currentValue * 100) / 100,
       currency: position.currency,
+      brandLogoName: position.brandLogoName,
     };
   });
 

--- a/pages/portfolio.tsx
+++ b/pages/portfolio.tsx
@@ -43,6 +43,7 @@ interface PortfolioResponse {
     investedAmount: number;
     currentValue: number;
     currency: string | null;
+    brandLogoName: string | null;
   }>;
   operations: Array<{
     id: string;

--- a/prisma/migrations/0003_add_brand_logo_name_to_positions/migration.sql
+++ b/prisma/migrations/0003_add_brand_logo_name_to_positions/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "PortfolioPosition" ADD COLUMN "brandLogoName" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -93,6 +93,7 @@ model PortfolioPosition {
   expectedYield        Float?
   expectedYieldPercent Float?
   currency             String?
+  brandLogoName        String?
   updatedAt            DateTime            @default(now())
 
   @@index([connectionId, figi])


### PR DESCRIPTION
## Summary
- capture brand logo identifiers from T-Bank instrument metadata and persist them on portfolio positions
- expose stored logo names through the portfolio API and client types
- render position avatars with Tinkoff CDN logos and allow Next.js to load the new domain

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e44c278a488330968ebb5683def535