### PR TITLE
Limit dashboard operations list and add T-Bank import

### DIFF
--- a/components/ExpenseImport.module.css
+++ b/components/ExpenseImport.module.css
@@ -14,11 +14,23 @@
   gap: 4px;
 }
 
+.titleRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .title {
   margin: 0;
   font-size: 18px;
   font-weight: 600;
   color: #fff;
+}
+
+.icon {
+  width: 32px;
+  height: 32px;
+  display: inline-flex;
 }
 
 .caption {
@@ -75,4 +87,9 @@
 
 .summary strong {
   color: #fff;
+}
+
+.muted {
+  color: rgba(255, 255, 255, 0.6);
+  font-weight: 400;
 }

--- a/components/ExpenseImport.tsx
+++ b/components/ExpenseImport.tsx
@@ -1,6 +1,8 @@
 'use client';
 
-import { ChangeEvent, useMemo, useRef, useState } from 'react';
+import { ChangeEvent, ReactNode, useMemo, useRef, useState } from 'react';
+
+import { TBankIcon } from './icons/TBankIcon';
 
 import styles from './ExpenseImport.module.css';
 
@@ -15,6 +17,10 @@ interface ImportCardProps extends Props {
   description: string;
   title: string;
   type: Mode;
+  icon?: ReactNode;
+  parser?: (content: string) => ParseResult;
+  hint?: string;
+  renderSummary?: (result: ImportResponse, localSkipped: number) => ReactNode;
 }
 
 interface ParsedOperation {
@@ -30,9 +36,26 @@ interface ImportResponse {
   categoriesCreated: number;
 }
 
-interface ParseResult {
-  operations: ParsedOperation[];
+interface ParseResult<T = ParsedOperation> {
+  operations: T[];
   skipped: number;
+}
+
+interface ParsedTBankOperation extends ParsedOperation {
+  type: Mode;
+}
+
+interface ImportBreakdown {
+  created: number;
+  skipped: number;
+  categoriesCreated: number;
+}
+
+interface TBankImportResponse extends ImportResponse {
+  breakdown: {
+    expenses: ImportBreakdown;
+    incomes: ImportBreakdown;
+  };
 }
 
 function normaliseHeader(value: string): string {
@@ -137,7 +160,118 @@ function parseTable(content: string): ParseResult {
   return { operations, skipped };
 }
 
-function ImportCard({ endpoint, description, onImported, title, type }: ImportCardProps) {
+function parseSignedAmount(raw: string): number | null {
+  const normalised = raw.replace(/[\s\u00a0]/g, '').replace(',', '.');
+  if (!normalised) return null;
+  const amount = Number(normalised);
+  if (!Number.isFinite(amount) || amount === 0) {
+    return null;
+  }
+  return amount;
+}
+
+function parseTBankDate(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+
+  const [datePart] = trimmed.split(/[ T]/);
+  if (!datePart) return null;
+
+  const separators = datePart.includes('.') ? /[.]/ : /[-/]/;
+  const parts = datePart.split(separators).filter(Boolean);
+  if (parts.length < 3) return null;
+
+  let day: number;
+  let month: number;
+  let year: number;
+
+  if (parts[0].length === 4) {
+    [year, month, day] = parts.map((value) => Number(value));
+  } else {
+    [day, month, year] = parts.map((value) => Number(value));
+  }
+
+  if (!Number.isInteger(day) || !Number.isInteger(month) || !Number.isInteger(year)) {
+    return null;
+  }
+
+  const date = new Date(Date.UTC(year, month - 1, day));
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  return date.toISOString().slice(0, 10);
+}
+
+function parseTBankTable(content: string): ParseResult<ParsedTBankOperation> {
+  const lines = content
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  if (lines.length === 0) {
+    return { operations: [], skipped: 0 };
+  }
+
+  const delimiter = detectDelimiter(lines[0]);
+  const headerCells = lines[0].split(delimiter).map(normaliseHeader);
+
+  const dateIndex = findHeaderIndex(headerCells, ['дата операции', 'дата платежа', 'operation date', 'date']);
+  const categoryIndex = findHeaderIndex(headerCells, ['катег', 'category']);
+  const amountIndex = findHeaderIndex(headerCells, ['сумма платеж', 'сумма операции', 'amount']);
+  const commentIndex = findHeaderIndex(headerCells, ['опис', 'назначение', 'comment']);
+
+  const operations: ParsedTBankOperation[] = [];
+  let skipped = 0;
+
+  for (let i = 1; i < lines.length; i += 1) {
+    const cells = lines[i].split(delimiter).map((cell) => cell.replace(/^"|"$/g, '').trim());
+
+    const dateRaw = dateIndex >= 0 ? cells[dateIndex] ?? '' : '';
+    const amountRaw = amountIndex >= 0 ? cells[amountIndex] ?? '' : '';
+
+    const date = parseTBankDate(dateRaw);
+    const signedAmount = parseSignedAmount(amountRaw);
+
+    if (!date || signedAmount === null) {
+      skipped += 1;
+      continue;
+    }
+
+    const type: Mode = signedAmount < 0 ? 'EXPENSE' : 'INCOME';
+    const amount = Math.abs(signedAmount);
+
+    if (amount === 0) {
+      skipped += 1;
+      continue;
+    }
+
+    const categoryValue = categoryIndex >= 0 ? cells[categoryIndex] ?? '' : '';
+    const commentValue = commentIndex >= 0 ? cells[commentIndex] ?? '' : '';
+
+    operations.push({
+      type,
+      amount,
+      date,
+      categoryName: categoryValue ? categoryValue.trim() : null,
+      description: commentValue ? commentValue.trim() : null,
+    });
+  }
+
+  return { operations, skipped };
+}
+
+function ImportCard({
+  endpoint,
+  description,
+  icon,
+  onImported,
+  title,
+  type,
+  parser,
+  hint: hintOverride,
+  renderSummary,
+}: ImportCardProps) {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState('');
   const [result, setResult] = useState<ImportResponse | null>(null);
@@ -145,11 +279,15 @@ function ImportCard({ endpoint, description, onImported, title, type }: ImportCa
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   const hint = useMemo(() => {
+    if (hintOverride) {
+      return hintOverride;
+    }
+
     if (type === 'INCOME') {
       return 'Категория обязательна для каждой строки.';
     }
     return 'Категория может быть пустой — мы сохраним расход без неё.';
-  }, [type]);
+  }, [hintOverride, type]);
 
   async function handleFileSelected(event: ChangeEvent<HTMLInputElement>) {
     const file = event.target.files?.[0];
@@ -162,7 +300,8 @@ function ImportCard({ endpoint, description, onImported, title, type }: ImportCa
 
     try {
       const text = await file.text();
-      const parsed = parseTable(text);
+      const parse = parser ?? parseTable;
+      const parsed = parse(text);
       if (parsed.operations.length === 0) {
         throw new Error('Не удалось найти операции в файле. Проверьте формат столбцов.');
       }
@@ -196,7 +335,10 @@ function ImportCard({ endpoint, description, onImported, title, type }: ImportCa
   return (
     <div className={styles.card}>
       <header className={styles.header}>
-        <h3 className={styles.title}>{title}</h3>
+        <div className={styles.titleRow}>
+          {icon ? <span className={styles.icon}>{icon}</span> : null}
+          <h3 className={styles.title}>{title}</h3>
+        </div>
         <p className={styles.caption}>{description}</p>
       </header>
 
@@ -226,15 +368,21 @@ function ImportCard({ endpoint, description, onImported, title, type }: ImportCa
 
       {result && (
         <div className={styles.summary}>
-          <span>
-            Импортировано: <strong>{result.created}</strong>
-          </span>
-          <span>
-            Создано категорий: <strong>{result.categoriesCreated}</strong>
-          </span>
-          <span>
-            Пропущено: <strong>{result.skipped + localSkipped}</strong>
-          </span>
+          {renderSummary ? (
+            renderSummary(result, localSkipped)
+          ) : (
+            <>
+              <span>
+                Импортировано: <strong>{result.created}</strong>
+              </span>
+              <span>
+                Создано категорий: <strong>{result.categoriesCreated}</strong>
+              </span>
+              <span>
+                Пропущено: <strong>{result.skipped + localSkipped}</strong>
+              </span>
+            </>
+          )}
         </div>
       )}
     </div>
@@ -260,6 +408,45 @@ export function IncomeImport({ onImported }: Props) {
       description="Загрузите CSV или TSV-файл с датой, категорией, суммой и комментарием — недостающие категории доходов создадутся автоматически."
       endpoint="/api/incomes/import"
       type="INCOME"
+      onImported={onImported}
+    />
+  );
+}
+
+export function TBankImport({ onImported }: Props) {
+  return (
+    <ImportCard
+      title="Т-Банк"
+      description="Загрузите выгрузку операций из Т-Банка — мы разделим поступления и расходы и сопоставим категории."
+      endpoint="/api/expenses/import-tbank"
+      type="EXPENSE"
+      icon={<TBankIcon width={32} height={32} />}
+      parser={parseTBankTable}
+      hint="Поддерживаются CSV- и TSV-файлы из интернет-банка Т-Банка."
+      renderSummary={(result, localSkipped) => {
+        const payload = result as TBankImportResponse;
+        const expenses = payload.breakdown?.expenses;
+        const incomes = payload.breakdown?.incomes;
+
+        return (
+          <>
+            <span>
+              Импортировано: <strong>{result.created}</strong>
+              {expenses && incomes ? (
+                <span className={styles.muted}>
+                  {' '}(расходы {expenses.created}, доходы {incomes.created})
+                </span>
+              ) : null}
+            </span>
+            <span>
+              Создано категорий: <strong>{result.categoriesCreated}</strong>
+            </span>
+            <span>
+              Пропущено: <strong>{result.skipped + localSkipped}</strong>
+            </span>
+          </>
+        );
+      }}
       onImported={onImported}
     />
   );

--- a/components/ExpenseTable.module.css
+++ b/components/ExpenseTable.module.css
@@ -27,6 +27,14 @@
   gap: 12px;
 }
 
+.emptyState {
+  padding: 24px;
+  border-radius: 16px;
+  border: 1px dashed rgba(255, 255, 255, 0.12);
+  text-align: center;
+  color: rgba(255, 255, 255, 0.6);
+}
+
 .rowHead,
 .row {
   display: grid;
@@ -79,6 +87,87 @@
   margin: 0;
 }
 
+.success {
+  color: #4ade80;
+  font-size: 13px;
+  margin: 0;
+}
+
+.footer {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.footerInfo {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  color: rgba(255, 255, 255, 0.75);
+  font-size: 14px;
+}
+
+.footerActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.exportControls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+
+.exportField {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.exportField input {
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 10px;
+  padding: 8px 12px;
+  color: #fff;
+}
+
+.exportButton {
+  padding: 12px 20px;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, #38bdf8, #818cf8);
+  color: #04060f;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.exportButton:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.clearButton {
+  padding: 10px 16px;
+  border-radius: 12px;
+  border: 1px solid rgba(248, 113, 113, 0.4);
+  background: rgba(248, 113, 113, 0.12);
+  color: #fca5a5;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.clearButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 @media (max-width: 1100px) {
   .rowHead,
   .row {
@@ -92,5 +181,19 @@
   .actionsCol {
     justify-content: flex-start;
     grid-column: span 3;
+  }
+
+  .footerActions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .exportControls {
+    width: 100%;
+  }
+
+  .exportButton,
+  .clearButton {
+    width: 100%;
   }
 }

--- a/components/icons/TBankIcon.tsx
+++ b/components/icons/TBankIcon.tsx
@@ -1,0 +1,19 @@
+import type { SVGProps } from 'react';
+
+export function TBankIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
+      <circle cx="16" cy="16" r="15" fill="#FFDD2D" />
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M9.6 11.2c0-.884.716-1.6 1.6-1.6h9.6c.884 0 1.6.716 1.6 1.6v1.6c0 .884-.716 1.6-1.6 1.6h-2.4v8c0 .884-.716 1.6-1.6 1.6h-1.6c-.884 0-1.6-.716-1.6-1.6v-8H11.2c-.884 0-1.6-.716-1.6-1.6v-1.6Z"
+        fill="#1A1A1A"
+      />
+      <path
+        d="M12 9l-1.5-2.4c-.24-.384.037-.864.48-.864h10.04c.442 0 .718.48.48.864L20 9h-8Z"
+        fill="#1A1A1A"
+      />
+    </svg>
+  );
+}

--- a/lib/period.ts
+++ b/lib/period.ts
@@ -1,0 +1,52 @@
+import { addMonths, endOfMonth, format, parseISO, startOfMonth, subMonths } from 'date-fns';
+
+export function parseBoundary(value?: string) {
+  if (!value) return null;
+
+  const normalized = value.length === 7 ? `${value}-01` : value;
+  const parsed = parseISO(normalized);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+
+  return parsed;
+}
+
+export function resolvePeriod(startRaw?: string, endRaw?: string) {
+  const now = new Date();
+  const fallbackStart = startOfMonth(now);
+  const fallbackEnd = endOfMonth(now);
+
+  const parsedStart = parseBoundary(startRaw);
+  const parsedEnd = parseBoundary(endRaw);
+
+  let start = startOfMonth(parsedStart ?? fallbackStart);
+  let end = endOfMonth(parsedEnd ?? fallbackEnd);
+
+  if (start.getTime() > end.getTime()) {
+    const tmp = start;
+    start = startOfMonth(end);
+    end = endOfMonth(tmp);
+  }
+
+  return { start, end };
+}
+
+export function buildTimelineRange(start: Date, monthsBack = 11) {
+  return {
+    from: startOfMonth(subMonths(start, monthsBack)),
+    to: endOfMonth(start),
+  };
+}
+
+export function enumerateMonths(from: Date, to: Date) {
+  const months: Date[] = [];
+  for (let cursor = from; cursor.getTime() <= to.getTime(); cursor = addMonths(cursor, 1)) {
+    months.push(cursor);
+  }
+  return months;
+}
+
+export function formatMonthKey(date: Date) {
+  return format(date, 'yyyy-MM');
+}

--- a/pages/api/expenses/export.ts
+++ b/pages/api/expenses/export.ts
@@ -1,0 +1,57 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { format } from 'date-fns';
+
+import { prisma } from '@/lib/prisma';
+import { requireAuth } from '@/lib/auth';
+import { resolvePeriod } from '@/lib/period';
+
+function escapeCell(value: string | number | null | undefined) {
+  const stringValue = value ?? '';
+  const normalised = typeof stringValue === 'number' ? stringValue.toString() : String(stringValue);
+  const escaped = normalised.replace(/"/g, '""');
+  return `"${escaped}"`;
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    return res.status(405).json({ message: 'Method not allowed' });
+  }
+
+  const userId = requireAuth(req, res);
+  if (!userId) return;
+
+  const { start, end } = resolvePeriod(
+    typeof req.query.start === 'string' ? req.query.start : undefined,
+    typeof req.query.end === 'string' ? req.query.end : undefined,
+  );
+
+  const expenses = await prisma.expense.findMany({
+    where: {
+      userId,
+      date: { gte: start, lte: end },
+    },
+    include: { category: true },
+    orderBy: { date: 'desc' },
+  });
+
+  const header = ['date', 'type', 'category', 'amount', 'description'];
+  const rows = expenses.map((expense) => {
+    const type = expense.category?.type === 'INCOME' ? 'INCOME' : 'EXPENSE';
+    const formattedDate = format(expense.date, 'yyyy-MM-dd');
+    const categoryName = expense.category?.name ?? '';
+    const amount = Number(expense.amount).toFixed(2);
+    const description = expense.description ?? '';
+
+    return [formattedDate, type, categoryName, amount, description];
+  });
+
+  const csvLines = [header, ...rows].map((row) => row.map(escapeCell).join(';'));
+  const csvContent = `\uFEFF${csvLines.join('\n')}`;
+
+  const filename = `finly-operations-${format(start, 'yyyyMMdd')}-${format(end, 'yyyyMMdd')}.csv`;
+
+  res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+  res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+  res.status(200).send(csvContent);
+}

--- a/pages/api/expenses/import-tbank.ts
+++ b/pages/api/expenses/import-tbank.ts
@@ -1,0 +1,100 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import { requireAuth } from '@/lib/auth';
+import { importOperations, type ImportOperationsResult, type OperationInput } from '@/lib/importOperations';
+
+interface TBankOperationInput extends OperationInput {
+  type: 'EXPENSE' | 'INCOME';
+}
+
+function mapOperations(operations: TBankOperationInput[]): OperationInput[] {
+  return operations.map(({ amount, categoryName, date, description }) => ({
+    amount,
+    categoryName,
+    date,
+    description,
+  }));
+}
+
+function summarize(result: ImportOperationsResult | undefined) {
+  if (!result) {
+    return { created: 0, categoriesCreated: 0, skipped: 0 };
+  }
+
+  return {
+    created: 'nothingToImport' in result && result.nothingToImport ? 0 : result.created,
+    categoriesCreated: result.categoriesCreated,
+    skipped: result.skipped,
+  };
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).json({ message: 'Method not allowed' });
+  }
+
+  const userId = requireAuth(req, res);
+  if (!userId) return;
+
+  const { operations } = req.body as { operations?: TBankOperationInput[] };
+
+  if (!Array.isArray(operations) || operations.length === 0) {
+    return res.status(400).json({ message: 'Список операций пуст' });
+  }
+
+  const expenseOperations = operations.filter((operation) => operation?.type !== 'INCOME');
+  const incomeOperations = operations.filter((operation) => operation?.type === 'INCOME');
+
+  if (expenseOperations.length === 0 && incomeOperations.length === 0) {
+    return res.status(400).json({ message: 'Список операций пуст' });
+  }
+
+  const results: ImportOperationsResult[] = [];
+
+  let expenseResult: ImportOperationsResult | undefined;
+  if (expenseOperations.length > 0) {
+    expenseResult = await importOperations({
+      operations: mapOperations(expenseOperations),
+      userId,
+      type: 'EXPENSE',
+    });
+    results.push(expenseResult);
+  }
+
+  let incomeResult: ImportOperationsResult | undefined;
+  if (incomeOperations.length > 0) {
+    incomeResult = await importOperations({
+      operations: mapOperations(incomeOperations),
+      userId,
+      type: 'INCOME',
+    });
+    results.push(incomeResult);
+  }
+
+  const created = results.reduce((total, current) => {
+    if ('nothingToImport' in current && current.nothingToImport) {
+      return total;
+    }
+    return total + current.created;
+  }, 0);
+
+  const categoriesCreated = results.reduce((total, current) => total + current.categoriesCreated, 0);
+  const skipped = results.reduce((total, current) => total + current.skipped, 0);
+
+  const nothingToImport =
+    results.length > 0 && results.every((item) => 'nothingToImport' in item && item.nothingToImport);
+
+  const breakdown = {
+    expenses: summarize(expenseResult),
+    incomes: summarize(incomeResult),
+  };
+
+  if (nothingToImport) {
+    return res
+      .status(400)
+      .json({ message: 'Не осталось валидных операций для импорта', skipped, breakdown, created, categoriesCreated });
+  }
+
+  return res.status(201).json({ created, categoriesCreated, skipped, breakdown });
+}

--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -10,7 +10,7 @@ import { DashboardLayout } from '@/components/DashboardLayout';
 import { MetricCard } from '@/components/MetricCard';
 import { SpendingChart } from '@/components/SpendingChart';
 import { ExpenseForm } from '@/components/ExpenseForm';
-import { ExpenseImport, IncomeImport } from '@/components/ExpenseImport';
+import { ExpenseImport, IncomeImport, TBankImport } from '@/components/ExpenseImport';
 import { ExpenseTable } from '@/components/ExpenseTable';
 import { CategoryForm } from '@/components/CategoryForm';
 import { CategoryList } from '@/components/CategoryList';
@@ -327,9 +327,12 @@ export default function Dashboard({ user }: DashboardProps) {
         />
       </section>
 
-      <section className={styles.gridTwoColumn}>
-        <ExpenseImport onImported={handleOperationsChanged} />
-        <IncomeImport onImported={handleOperationsChanged} />
+      <section className={styles.gridSingle}>
+        <div className={styles.importGrid}>
+          <ExpenseImport onImported={handleOperationsChanged} />
+          <IncomeImport onImported={handleOperationsChanged} />
+          <TBankImport onImported={handleOperationsChanged} />
+        </div>
       </section>
 
       <section className={styles.gridSingle}>
@@ -337,6 +340,8 @@ export default function Dashboard({ user }: DashboardProps) {
           expenses={expenses.data?.expenses ?? []}
           categories={categories.data?.categories ?? []}
           onChanged={handleOperationsChanged}
+          periodStart={expenses.data?.periodStart}
+          periodEnd={expenses.data?.periodEnd}
         />
       </section>
     </DashboardLayout>

--- a/styles/Dashboard.module.css
+++ b/styles/Dashboard.module.css
@@ -102,6 +102,12 @@
   margin-bottom: 32px;
 }
 
+.importGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 20px;
+}
+
 @media (max-width: 768px) {
   .headerRow {
     flex-direction: column;


### PR DESCRIPTION
## Summary
- show only the latest dashboard operations with export controls and bulk delete support
- add CSV export endpoint and shared period utilities for expenses APIs
- introduce a dedicated T-Bank import flow with icon and server-side processing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68efd75fe94c8330a62241500979ad54