### PR TITLE
Fix dashboard timeline and stack expenses by category

### DIFF
--- a/pages/dashboard.tsx
+++ b/pages/dashboard.tsx
@@ -49,6 +49,18 @@ interface ExpenseItem {
   } | null;
 }
 
+interface MonthlyDataPoint {
+  date: string;
+  income: number;
+  expenses: number;
+  expenseBreakdown: Array<{
+    id: string;
+    name: string;
+    color: string | null;
+    amount: number;
+  }>;
+}
+
 interface AnalyticsResponse {
   totals: {
     income: number;
@@ -137,7 +149,7 @@ export default function Dashboard({ user }: DashboardProps) {
   const categories = useSWR<{ categories: Category[] }>(categoriesKey);
   const expenses = useSWR<{
     expenses: ExpenseItem[];
-    monthly: Array<{ date: string; income: number; expenses: number }>;
+    monthly: MonthlyDataPoint[];
     totals: { income: number; expenses: number };
   }>(
     expensesKey,
@@ -301,7 +313,10 @@ export default function Dashboard({ user }: DashboardProps) {
       </section>
 
       <section className={styles.gridSingle}>
-        <SpendingChart data={expenses.data?.monthly ?? []} />
+        <SpendingChart
+          data={expenses.data?.monthly ?? []}
+          categories={categories.data?.categories ?? []}
+        />
       </section>
 
       <section className={styles.gridSingle}>


### PR DESCRIPTION
## Summary
- adjust the expenses API timeline to cover the selected period and expose monthly category breakdowns
- render the dashboard spending chart as stacked bars per expense category with consistent colours
- pass category data to the chart so expenses can be grouped visually while keeping income bars intact

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68efdf3f5304833097d96d31375d0612