### PR TITLE
Separate income and expense analytics

### DIFF
--- a/components/BalanceTrendChart.tsx
+++ b/components/BalanceTrendChart.tsx
@@ -32,15 +32,18 @@ export function BalanceTrendChart({ data }: Props) {
   );
 
   const chartData = useMemo(() => {
+    let runningBalance = 0;
     return sorted.map((point) => {
       const parsed = new Date(point.date);
       const labelRaw = format(parsed, 'LLLL yyyy', { locale: ru });
       const label = labelRaw.charAt(0).toUpperCase() + labelRaw.slice(1);
-      const balance = point.income - point.expenses;
+      const delta = point.income - point.expenses;
+      runningBalance += delta;
       return {
         ...point,
         label,
-        balance,
+        balance: runningBalance,
+        delta,
       };
     });
   }, [sorted]);
@@ -85,10 +88,19 @@ export function BalanceTrendChart({ data }: Props) {
                 border: '1px solid rgba(255, 255, 255, 0.1)',
                 borderRadius: 12,
               }}
-              formatter={(value: number, name: string) => [
-                `${Math.round(value).toLocaleString('ru-RU')} ₽`,
-                name === 'balance' ? 'Баланс' : name,
-              ]}
+              formatter={(value: number, name: string) => {
+                const formatted = `${Math.round(value).toLocaleString('ru-RU')} ₽`;
+                if (name === 'balance') {
+                  return [formatted, 'Накопленный баланс'];
+                }
+                if (name === 'income') {
+                  return [formatted, 'Доходы'];
+                }
+                if (name === 'expenses') {
+                  return [formatted, 'Расходы'];
+                }
+                return [formatted, name];
+              }}
               labelFormatter={(label) => label}
             />
             <Legend wrapperStyle={{ paddingTop: 12 }} />
@@ -97,7 +109,7 @@ export function BalanceTrendChart({ data }: Props) {
               dataKey="balance"
               stroke="#38bdf8"
               fill="rgba(56, 189, 248, 0.2)"
-              name="Баланс"
+              name="Накопленный баланс"
               strokeWidth={2}
             />
             <Area

--- a/components/ExpenseTable.tsx
+++ b/components/ExpenseTable.tsx
@@ -38,6 +38,11 @@ export function ExpenseTable({ expenses, categories, onChanged, periodStart, per
   const [exportStart, setExportStart] = useState(periodStart ?? '');
   const [exportEnd, setExportEnd] = useState(periodEnd ?? '');
 
+  const expenseOnly = useMemo(
+    () => expenses.filter((expense) => expense.category?.type !== 'INCOME'),
+    [expenses],
+  );
+
   useEffect(() => {
     setExportStart(periodStart ?? '');
   }, [periodStart]);
@@ -46,8 +51,8 @@ export function ExpenseTable({ expenses, categories, onChanged, periodStart, per
     setExportEnd(periodEnd ?? '');
   }, [periodEnd]);
 
-  const displayedExpenses = useMemo(() => expenses.slice(0, 10), [expenses]);
-  const hasMoreExpenses = expenses.length > displayedExpenses.length;
+  const displayedExpenses = useMemo(() => expenseOnly.slice(0, 10), [expenseOnly]);
+  const hasMoreExpenses = expenseOnly.length > displayedExpenses.length;
 
   async function updateExpense(id: string, payload: Record<string, unknown>) {
     setError('');
@@ -273,7 +278,7 @@ export function ExpenseTable({ expenses, categories, onChanged, periodStart, per
             type="button"
             onClick={handleDeleteAll}
             className={styles.clearButton}
-            disabled={isClearing || displayedExpenses.length === 0}
+            disabled={isClearing || expenseOnly.length === 0}
           >
             {isClearing ? 'Удаляем…' : 'Удалить все операции'}
           </button>

--- a/lib/financeFilters.ts
+++ b/lib/financeFilters.ts
@@ -1,0 +1,22 @@
+export interface CategorizedEntity {
+  name?: string | null;
+}
+
+const TRANSFER_KEYWORDS = ['перевод', 'transfer', 'между счет', 'между счё'];
+
+export function isTransferCategory(category?: CategorizedEntity | null): boolean {
+  if (!category || !category.name) {
+    return false;
+  }
+
+  const normalized = category.name.trim().toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+
+  return TRANSFER_KEYWORDS.some((keyword) => normalized.includes(keyword));
+}
+
+export function shouldIgnoreCategory(category?: CategorizedEntity | null): boolean {
+  return isTransferCategory(category);
+}

--- a/pages/api/analytics/overview.ts
+++ b/pages/api/analytics/overview.ts
@@ -3,6 +3,7 @@ import { endOfMonth, formatISO, parseISO, startOfMonth, subDays } from 'date-fns
 
 import { prisma } from '@/lib/prisma';
 import { requireAuth } from '@/lib/auth';
+import { shouldIgnoreCategory } from '@/lib/financeFilters';
 
 function parseBoundary(value?: string) {
   if (!value) return null;
@@ -64,6 +65,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const daySet = new Set<string>();
 
   expenses.forEach((expense) => {
+    if (shouldIgnoreCategory(expense.category)) {
+      return;
+    }
+
     const amount = Number(expense.amount);
     const key = expense.categoryId ?? 'uncategorized';
     const entry = byCategory.get(key);

--- a/pages/api/categories/index.ts
+++ b/pages/api/categories/index.ts
@@ -4,6 +4,7 @@ import { endOfMonth, parseISO, startOfMonth } from 'date-fns';
 
 import { prisma } from '@/lib/prisma';
 import { requireAuth } from '@/lib/auth';
+import { shouldIgnoreCategory } from '@/lib/financeFilters';
 
 function parseBoundary(value?: string) {
   if (!value) return null;
@@ -82,6 +83,8 @@ async function getCategories(req: NextApiRequest, res: NextApiResponse) {
     }),
   ]);
 
+  const filteredOperations = operations.filter((operation) => !shouldIgnoreCategory(operation.category));
+
   const usedCategoryIds = new Set(
     usageCounts
       .map((item) => item.categoryId)
@@ -102,7 +105,7 @@ async function getCategories(req: NextApiRequest, res: NextApiResponse) {
   }
 
   const totalsByCategory = new Map<string, { income: number; expenses: number }>();
-  operations.forEach((operation) => {
+  filteredOperations.forEach((operation) => {
     if (!operation.categoryId || !operation.category) return;
     const amount = Number(operation.amount);
     const bucket = totalsByCategory.get(operation.categoryId) ?? { income: 0, expenses: 0 };

--- a/pages/dashboard/balance.tsx
+++ b/pages/dashboard/balance.tsx
@@ -53,14 +53,24 @@ export default function BalanceDashboardPage({ user }: BalanceDashboardProps) {
     [expenses.data?.monthly],
   );
 
-  const monthlyBalances = useMemo(
+  const sortedMonthlyPoints = useMemo(
     () =>
-      monthlyPoints.map((point) => ({
-        date: point.date,
-        balance: point.income - point.expenses,
-      })),
+      [...monthlyPoints].sort(
+        (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
+      ),
     [monthlyPoints],
   );
+
+  const monthlyBalances = useMemo(() => {
+    let runningBalance = 0;
+    return sortedMonthlyPoints.map((point) => {
+      runningBalance += point.income - point.expenses;
+      return {
+        date: point.date,
+        balance: runningBalance,
+      };
+    });
+  }, [sortedMonthlyPoints]);
 
   const bestMonth = useMemo(() => {
     if (!monthlyBalances.length) {
@@ -123,7 +133,7 @@ export default function BalanceDashboardPage({ user }: BalanceDashboardProps) {
       </section>
 
       <section className={styles.gridSingle}>
-        <BalanceTrendChart data={monthlyPoints} />
+        <BalanceTrendChart data={sortedMonthlyPoints} />
       </section>
 
       <section className={styles.gridSingle}>


### PR DESCRIPTION
## Summary
- exclude transfer-style categories from analytics aggregation and expense listings
- keep income operations out of the expenses dashboard tables
- make the balance dashboard cumulative so the trend chart and metrics reflect the running total

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68efebad2bb083308b18b9f5c41bf079