### PR TITLE
Fix expense timeline and enforce category-specific operations

### DIFF
--- a/components/CategoryForm.module.css
+++ b/components/CategoryForm.module.css
@@ -27,6 +27,15 @@
   font-size: 15px;
 }
 
+.readonlyField {
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(10, 10, 18, 0.4);
+  color: rgba(255, 255, 255, 0.8);
+  padding: 12px 14px;
+  font-size: 15px;
+}
+
 .error {
   margin: 0;
   color: #fca5a5;

--- a/components/CategoryForm.tsx
+++ b/components/CategoryForm.tsx
@@ -4,13 +4,18 @@ import styles from './CategoryForm.module.css';
 
 type CategoryType = 'INCOME' | 'EXPENSE';
 
+type Mode = 'ALL' | 'INCOME' | 'EXPENSE';
+
 interface Props {
   onCreated: () => void;
+  mode?: Mode;
 }
 
-export function CategoryForm({ onCreated }: Props) {
+export function CategoryForm({ onCreated, mode = 'ALL' }: Props) {
   const [name, setName] = useState('');
-  const [type, setType] = useState<CategoryType>('EXPENSE');
+  const [type, setType] = useState<CategoryType>(
+    mode === 'INCOME' ? 'INCOME' : 'EXPENSE',
+  );
   const [budget, setBudget] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState('');
@@ -34,7 +39,7 @@ export function CategoryForm({ onCreated }: Props) {
 
       setName('');
       setBudget('');
-      setType('EXPENSE');
+      setType(mode === 'INCOME' ? 'INCOME' : 'EXPENSE');
       onCreated();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Ошибка');
@@ -49,13 +54,20 @@ export function CategoryForm({ onCreated }: Props) {
         <span>Название</span>
         <input value={name} onChange={(event) => setName(event.target.value)} placeholder="Категория" required />
       </label>
-      <label className={styles.field}>
-        <span>Тип</span>
-        <select value={type} onChange={(event) => setType(event.target.value as CategoryType)}>
-          <option value="EXPENSE">Расход</option>
-          <option value="INCOME">Доход</option>
-        </select>
-      </label>
+      {mode === 'ALL' ? (
+        <label className={styles.field}>
+          <span>Тип</span>
+          <select value={type} onChange={(event) => setType(event.target.value as CategoryType)}>
+            <option value="EXPENSE">Расход</option>
+            <option value="INCOME">Доход</option>
+          </select>
+        </label>
+      ) : (
+        <div className={styles.field}>
+          <span>Тип</span>
+          <div className={styles.readonlyField}>{mode === 'INCOME' ? 'Доход' : 'Расход'}</div>
+        </div>
+      )}
       <label className={styles.field}>
         <span>Лимит в месяц, ₽</span>
         <input

--- a/components/ExpenseForm.tsx
+++ b/components/ExpenseForm.tsx
@@ -63,7 +63,13 @@ export function ExpenseForm({
       const response = await fetch('/api/expenses', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ amount: Number(amount), categoryId: categoryId || null, description, date }),
+        body: JSON.stringify({
+          amount: Number(amount),
+          categoryId: categoryId || null,
+          description,
+          date,
+          type: mode,
+        }),
       });
 
       if (!response.ok) {

--- a/components/PortfolioPositions.tsx
+++ b/components/PortfolioPositions.tsx
@@ -25,6 +25,33 @@ interface Props {
   positions: PositionRow[];
 }
 
+const fallbackLogos: Record<string, { url: string; companyName: string }> = {
+  ROSN: {
+    url: 'https://beststocks.ru/api/file/stock/logos/RU:ROSN.png',
+    companyName: 'Роснефть',
+  },
+  RNFT: {
+    url: 'https://beststocks.ru/api/file/stock/logos/RU:RNFT.png',
+    companyName: 'Сургутнефтегаз',
+  },
+  TATN: {
+    url: 'https://beststocks.ru/api/file/stock/logos/RU:TATN.png',
+    companyName: 'Татнефть',
+  },
+  GAZP: {
+    url: 'https://beststocks.ru/api/file/stock/logos/RU:GAZP.png',
+    companyName: 'Газпром',
+  },
+  SBER: {
+    url: 'https://beststocks.ru/api/file/stock/logos/RU:SBER.png',
+    companyName: 'Сбер',
+  },
+  LKOH: {
+    url: 'https://beststocks.ru/api/file/stock/logos/RU:LKOH.png',
+    companyName: 'Лукойл',
+  },
+};
+
 const instrumentTypeLabels: Record<string, string> = {
   share: 'Акция',
   bond: 'Облигация',
@@ -40,20 +67,34 @@ function getInstrumentTypeLabel(type: string | null) {
   return instrumentTypeLabels[normalized] ?? type;
 }
 
-function getInstrumentLogoUrl(position: PositionRow) {
+function getInstrumentLogo(position: PositionRow) {
   const logoName = position.brandLogoName?.trim();
-  if (!logoName) return null;
+  if (logoName) {
+    const baseName = logoName.replace(/\.png$/i, '');
+    if (baseName) {
+      return {
+        url: `https://invest-brands.cdn-tinkoff.ru/${baseName}x160.png`,
+        label: position.name ?? position.ticker ?? position.figi,
+      };
+    }
+  }
 
-  const baseName = logoName.replace(/\.png$/i, '');
-  if (!baseName) return null;
+  const ticker = position.ticker?.trim().toUpperCase();
+  if (ticker && fallbackLogos[ticker]) {
+    return {
+      url: fallbackLogos[ticker].url,
+      label: fallbackLogos[ticker].companyName,
+    };
+  }
 
-  return `https://invest-brands.cdn-tinkoff.ru/${baseName}x160.png`;
+  return null;
 }
 
 function InstrumentLogo({ position }: { position: PositionRow }) {
   const [showImage, setShowImage] = useState(true);
-  const instrumentName = position.name ?? position.ticker ?? position.figi;
-  const logoUrl = getInstrumentLogoUrl(position);
+  const logo = getInstrumentLogo(position);
+  const instrumentName = logo?.label ?? position.name ?? position.ticker ?? position.figi;
+  const logoUrl = logo?.url;
 
   const fallbackLetters = (instrumentName ?? '—')
     .replace(/[^A-Za-zА-Яа-я0-9]/g, '')

--- a/hooks/useDashboardData.ts
+++ b/hooks/useDashboardData.ts
@@ -92,9 +92,6 @@ export interface DashboardData {
       periodEnd?: string;
     }>
   >;
-  activeCategories: Category[];
-  allCategories: Category[];
-  chartCategories: Category[];
   expenseCategories: Category[];
   incomeCategories: Category[];
   handleOperationsChanged: () => void;
@@ -156,10 +153,6 @@ export function useDashboardData(): DashboardData {
     periodEnd?: string;
   }>(`/api/expenses?${periodQuery}`);
 
-  const activeCategories = useMemo(
-    () => categories.data?.categories ?? [],
-    [categories.data?.categories],
-  );
   const allCategories = useMemo(
     () => categories.data?.allCategories ?? categories.data?.categories ?? [],
     [categories.data?.allCategories, categories.data?.categories],
@@ -250,23 +243,6 @@ export function useDashboardData(): DashboardData {
     categories.mutate();
   }, [analytics, categories, expenses]);
 
-  const chartCategories = useMemo(() => {
-    if (!expenses.data?.monthly?.length) {
-      return activeCategories;
-    }
-
-    const usedCategoryIds = new Set<string>();
-    expenses.data.monthly.forEach((point) => {
-      point.expenseBreakdown.forEach((item) => {
-        if (item.id) {
-          usedCategoryIds.add(item.id);
-        }
-      });
-    });
-
-    return activeCategories.filter((category) => usedCategoryIds.has(category.id));
-  }, [activeCategories, expenses.data?.monthly]);
-
   return {
     timeframe,
     periodLabel,
@@ -276,9 +252,6 @@ export function useDashboardData(): DashboardData {
     analytics,
     categories,
     expenses,
-    activeCategories,
-    allCategories,
-    chartCategories,
     expenseCategories,
     incomeCategories,
     handleOperationsChanged,

--- a/pages/api/expenses/[id].ts
+++ b/pages/api/expenses/[id].ts
@@ -1,4 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { CategoryType } from '@prisma/client';
 
 import { prisma } from '@/lib/prisma';
 import { requireAuth } from '@/lib/auth';
@@ -25,7 +26,7 @@ async function updateExpense(req: NextApiRequest, res: NextApiResponse) {
     return res.status(400).json({ message: 'Некорректный идентификатор' });
   }
 
-  const current = await prisma.expense.findFirst({ where: { id, userId } });
+  const current = await prisma.expense.findFirst({ where: { id, userId }, include: { category: true } });
   if (!current) {
     return res.status(404).json({ message: 'Трата не найдена' });
   }
@@ -54,13 +55,25 @@ async function updateExpense(req: NextApiRequest, res: NextApiResponse) {
   }
 
   if (categoryId !== undefined) {
+    const currentType = current.category?.type ?? CategoryType.EXPENSE;
+
     if (categoryId === null) {
+      if (currentType === CategoryType.INCOME) {
+        return res.status(400).json({ message: 'Доходы должны быть привязаны к категории' });
+      }
       data.categoryId = null;
     } else {
       const category = await prisma.category.findFirst({ where: { id: categoryId, userId } });
       if (!category) {
         return res.status(404).json({ message: 'Категория не найдена' });
       }
+
+      if (category.type !== currentType) {
+        return res
+          .status(400)
+          .json({ message: 'Нельзя менять тип операции, выберите подходящую категорию' });
+      }
+
       data.categoryId = categoryId;
     }
   }

--- a/pages/dashboard/expenses.tsx
+++ b/pages/dashboard/expenses.tsx
@@ -34,9 +34,7 @@ export default function ExpensesDashboardPage({ user }: DashboardPageProps) {
     canNavigateForward,
     analytics,
     expenses,
-    chartCategories,
     expenseCategories,
-    allCategories,
     handleOperationsChanged,
   } = useDashboardData();
 
@@ -107,7 +105,7 @@ export default function ExpensesDashboardPage({ user }: DashboardPageProps) {
       </section>
 
       <section className={styles.gridSingle}>
-        <SpendingChart data={monthlyPoints} categories={chartCategories} />
+        <SpendingChart data={monthlyPoints} />
       </section>
 
       <section className={styles.gridSingle}>
@@ -115,7 +113,7 @@ export default function ExpensesDashboardPage({ user }: DashboardPageProps) {
       </section>
 
       <section className={styles.gridTwoColumn}>
-        <CategoryForm onCreated={handleOperationsChanged} />
+        <CategoryForm mode="EXPENSE" onCreated={handleOperationsChanged} />
         <StreakCard streak={analytics.data?.streak ?? 0} />
       </section>
 
@@ -134,7 +132,8 @@ export default function ExpensesDashboardPage({ user }: DashboardPageProps) {
       <section className={styles.gridSingle}>
         <ExpenseTable
           expenses={expenses.data?.expenses ?? []}
-          categories={allCategories}
+          categories={expenseCategories}
+          allowUncategorized
           onChanged={handleOperationsChanged}
           periodStart={expenses.data?.periodStart}
           periodEnd={expenses.data?.periodEnd}

--- a/pages/dashboard/income.tsx
+++ b/pages/dashboard/income.tsx
@@ -123,7 +123,7 @@ export default function IncomeDashboardPage({ user }: IncomeDashboardProps) {
       </section>
 
       <section className={styles.gridTwoColumn}>
-        <CategoryForm onCreated={handleOperationsChanged} />
+        <CategoryForm mode="INCOME" onCreated={handleOperationsChanged} />
         <ExpenseForm
           mode="INCOME"
           categories={incomeCategories}


### PR DESCRIPTION
## Summary
- lock category creation forms and operation forms to their respective income or expense types
- update expense APIs and table UI to enforce type safety and show full-period timelines
- align expense chart styling with income chart and add portfolio logo fallbacks

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f00b0db4608330a53df7e48ccef2a9