### PR TITLE
Add income dashboard parity and improve breakdown visuals

### DIFF
--- a/components/BreakdownList.module.css
+++ b/components/BreakdownList.module.css
@@ -27,6 +27,12 @@
   color: rgba(255, 255, 255, 0.6);
 }
 
+.placeholder {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 14px;
+}
+
 .list {
   list-style: none;
   padding: 0;

--- a/components/BreakdownList.tsx
+++ b/components/BreakdownList.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import styles from './BreakdownList.module.css';
 import { ProgressBar } from './ProgressBar';
 
@@ -25,19 +27,31 @@ function formatShare(value: number): string {
 }
 
 export function BreakdownList({ items }: Props) {
-  const total = items.reduce((sum, item) => sum + item.spent, 0);
+  const sortedItems = useMemo(() => [...items].sort((a, b) => b.spent - a.spent), [items]);
+  const total = sortedItems.reduce((sum, item) => sum + item.spent, 0);
+
+  if (sortedItems.length === 0) {
+    return (
+      <div className={styles.container}>
+        <div className={styles.header}>
+          <h3 className={styles.title}>Топ расходов</h3>
+        </div>
+        <p className={styles.placeholder}>Добавьте расходы, чтобы увидеть распределение по категориям.</p>
+      </div>
+    );
+  }
 
   return (
     <div className={styles.container}>
       <div className={styles.header}>
         <h3 className={styles.title}>Топ расходов</h3>
         <div className={styles.summary}>
-          <span>Категорий: {items.length}</span>
+          <span>Категорий: {sortedItems.length}</span>
           <span>Всего: {formatCurrency(total)}</span>
         </div>
       </div>
       <ul className={styles.list}>
-        {items.map((item) => {
+        {sortedItems.map((item) => {
           const share = total > 0 ? (item.spent / total) * 100 : 0;
           const limitLabel = item.budget ? `Лимит ${formatCurrency(item.budget)}` : 'Лимит не задан';
           let statusLabel: string | null = null;
@@ -64,7 +78,11 @@ export function BreakdownList({ items }: Props) {
                 </div>
               </div>
               <div className={styles.progressBlock}>
-                <ProgressBar value={item.progress ?? 0} color={item.color ?? undefined} />
+                <ProgressBar value={share / 100} color={item.color ?? undefined} />
+                <div className={styles.captionRow}>
+                  <span className={styles.caption}>Доля от всех расходов</span>
+                  <span className={styles.caption}>{formatShare(share)}</span>
+                </div>
                 <div className={styles.captionRow}>
                   <span className={`${styles.status} ${styles[statusTone]}`}>{statusLabel}</span>
                   <span className={styles.caption}>{limitLabel}</span>

--- a/components/ExpenseTable.tsx
+++ b/components/ExpenseTable.tsx
@@ -28,6 +28,7 @@ interface Props {
   periodStart?: string;
   periodEnd?: string;
   allowUncategorized?: boolean;
+  mode?: 'EXPENSES' | 'INCOME' | 'ALL';
 }
 
 export function ExpenseTable({
@@ -37,6 +38,7 @@ export function ExpenseTable({
   periodStart,
   periodEnd,
   allowUncategorized = true,
+  mode = 'EXPENSES',
 }: Props) {
   const [error, setError] = useState('');
   const [exportError, setExportError] = useState('');
@@ -46,10 +48,15 @@ export function ExpenseTable({
   const [exportStart, setExportStart] = useState(periodStart ?? '');
   const [exportEnd, setExportEnd] = useState(periodEnd ?? '');
 
-  const expenseOnly = useMemo(
-    () => expenses.filter((expense) => expense.category?.type !== 'INCOME'),
-    [expenses],
-  );
+  const filteredOperations = useMemo(() => {
+    if (mode === 'ALL') {
+      return expenses;
+    }
+
+    return expenses.filter((expense) =>
+      mode === 'INCOME' ? expense.category?.type === 'INCOME' : expense.category?.type !== 'INCOME',
+    );
+  }, [expenses, mode]);
 
   useEffect(() => {
     setExportStart(periodStart ?? '');
@@ -59,8 +66,8 @@ export function ExpenseTable({
     setExportEnd(periodEnd ?? '');
   }, [periodEnd]);
 
-  const displayedExpenses = useMemo(() => expenseOnly.slice(0, 10), [expenseOnly]);
-  const hasMoreExpenses = expenseOnly.length > displayedExpenses.length;
+  const displayedExpenses = useMemo(() => filteredOperations.slice(0, 10), [filteredOperations]);
+  const hasMoreExpenses = filteredOperations.length > displayedExpenses.length;
 
   async function updateExpense(id: string, payload: Record<string, unknown>) {
     setError('');
@@ -274,7 +281,7 @@ export function ExpenseTable({
         <div className={styles.footerInfo}>
           <span>
             {displayedExpenses.length > 0
-              ? `Показано операций: ${displayedExpenses.length} из ${expenseOnly.length}`
+              ? `Показано операций: ${displayedExpenses.length} из ${filteredOperations.length}`
               : 'Нет операций для отображения'}
           </span>
           {hasMoreExpenses ? (
@@ -303,7 +310,7 @@ export function ExpenseTable({
             type="button"
             onClick={handleDeleteAll}
             className={styles.clearButton}
-            disabled={isClearing || expenseOnly.length === 0}
+            disabled={isClearing || filteredOperations.length === 0}
           >
             {isClearing ? 'Удаляем…' : 'Удалить все операции'}
           </button>

--- a/components/IncomeHighlightsCard.module.css
+++ b/components/IncomeHighlightsCard.module.css
@@ -1,0 +1,59 @@
+.card {
+  background: rgba(34, 197, 94, 0.08);
+  border: 1px solid rgba(34, 197, 94, 0.2);
+  border-radius: 24px;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.placeholder {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.65);
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+.highlight {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+}
+
+.name {
+  font-weight: 600;
+  font-size: 16px;
+}
+
+.amount {
+  font-size: 32px;
+  font-weight: 700;
+}
+
+.caption {
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+@media (max-width: 720px) {
+  .card {
+    padding: 20px;
+  }
+
+  .amount {
+    font-size: 28px;
+  }
+}

--- a/components/IncomeHighlightsCard.tsx
+++ b/components/IncomeHighlightsCard.tsx
@@ -1,0 +1,52 @@
+import styles from './IncomeHighlightsCard.module.css';
+
+interface IncomeHighlight {
+  name: string;
+  amount: number;
+  color?: string | null;
+}
+
+interface Props {
+  topCategory: IncomeHighlight | null;
+  totalIncome: number;
+}
+
+function formatCurrency(value: number): string {
+  return `${Math.round(value).toLocaleString('ru-RU')} ₽`;
+}
+
+function formatShare(amount: number, total: number): string {
+  if (total === 0) {
+    return '0%';
+  }
+
+  const share = (amount / total) * 100;
+  if (share === 0) return '0%';
+  if (share < 1) return '<1%';
+  return `${share.toFixed(share >= 10 ? 0 : 1)}%`;
+}
+
+export function IncomeHighlightsCard({ topCategory, totalIncome }: Props) {
+  if (!topCategory) {
+    return (
+      <div className={styles.card}>
+        <h3 className={styles.title}>Лидирующий источник</h3>
+        <p className={styles.placeholder}>Добавьте доходы, чтобы увидеть ключевой источник.</p>
+      </div>
+    );
+  }
+
+  const shareLabel = formatShare(topCategory.amount, totalIncome);
+
+  return (
+    <div className={styles.card}>
+      <h3 className={styles.title}>Лидирующий источник</h3>
+      <div className={styles.highlight}>
+        <span className={styles.dot} style={{ background: topCategory.color ?? '#22c55e' }} />
+        <span className={styles.name}>{topCategory.name}</span>
+      </div>
+      <div className={styles.amount}>{formatCurrency(topCategory.amount)}</div>
+      <span className={styles.caption}>Доля от всех доходов — {shareLabel}</span>
+    </div>
+  );
+}

--- a/hooks/useDashboardData.ts
+++ b/hooks/useDashboardData.ts
@@ -147,6 +147,7 @@ export function useDashboardData(): DashboardData {
   );
   const expenses = useSWR<{
     expenses: ExpenseItem[];
+    incomes: ExpenseItem[];
     monthly: MonthlyDataPoint[];
     totals: { income: number; expenses: number };
     periodStart?: string;

--- a/pages/api/expenses/index.ts
+++ b/pages/api/expenses/index.ts
@@ -60,6 +60,7 @@ async function listExpenses(req: NextApiRequest, res: NextApiResponse) {
   });
 
   const expenseOperations = filteredRawExpenses.filter((expense) => expense.category?.type !== 'INCOME');
+  const incomeOperations = filteredRawExpenses.filter((expense) => expense.category?.type === 'INCOME');
 
   const monthlyTotals = new Map<
     string,
@@ -143,8 +144,14 @@ async function listExpenses(req: NextApiRequest, res: NextApiResponse) {
     amount: Number(item.amount),
   }));
 
+  const incomes = incomeOperations.map((item) => ({
+    ...item,
+    amount: Number(item.amount),
+  }));
+
   return res.status(200).json({
     expenses,
+    incomes,
     totals,
     monthly,
     periodStart: formatISO(start, { representation: 'date' }),


### PR DESCRIPTION
## Summary
- expose income operations in the expenses API and hook consumers
- mirror the expenses dashboard for income, adding highlight and operations sections
- refresh the spending breakdown list styling to better surface top categories

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f0170d0df8833096ace3962450009f