### PR TITLE
Adjust expense table layout to prevent amount overlap

### DIFF
--- a/components/ExpenseTable.module.css
+++ b/components/ExpenseTable.module.css
@@ -38,7 +38,8 @@
 .rowHead,
 .row {
   display: grid;
-  grid-template-columns: 120px 1fr 160px 140px 200px;
+  grid-template-columns: minmax(100px, 120px) minmax(0, 1.6fr) minmax(140px, 1fr)
+    minmax(140px, max-content) minmax(220px, max-content);
   gap: 12px;
   align-items: center;
 }
@@ -57,12 +58,14 @@
 .amountCol {
   text-align: right;
   font-variant-numeric: tabular-nums;
+  white-space: nowrap;
 }
 
 .actionsCol {
   display: flex;
   gap: 8px;
   justify-content: flex-end;
+  flex-wrap: wrap;
 }
 
 .actionsCol button {
@@ -74,6 +77,7 @@
   cursor: pointer;
   font-size: 13px;
   font-weight: 600;
+  white-space: nowrap;
 }
 
 .danger {


### PR DESCRIPTION
## Summary
- tweak the expense table grid to give the amount and action columns more flexible space
- prevent the amount value and action buttons from overlapping by keeping amounts on a single line and allowing buttons to wrap

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f0192d56f48330a9d95086cdad416b