### PR TITLE
Enable combined portfolio aggregation across accounts

### DIFF
--- a/lib/investAccounts.ts
+++ b/lib/investAccounts.ts
@@ -1,0 +1,2 @@
+export const ALL_ACCOUNTS_ID = '__all__';
+export const ALL_ACCOUNTS_LABEL = 'Совокупный портфель';


### PR DESCRIPTION
## Summary
- add shared constants and update Tinkoff portfolio sync logic to support the combined "Совокупный портфель" selection
- include the consolidated portfolio option when multiple accounts are returned during connection setup
- update the portfolio UI to label combined accounts, surface the new dropdown option, and auto-select it when already linked

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f01ed37a288330a0ad6968917c2066