### PR TITLE
Fix combined portfolio sync across accounts

### DIFF
--- a/lib/investAccounts.ts
+++ b/lib/investAccounts.ts
@@ -1,0 +1,2 @@
+export const ALL_ACCOUNTS_ID = '__all__';
+export const ALL_ACCOUNTS_LABEL = 'Совокупный портфель';


### PR DESCRIPTION
## Summary
- resolve the combined "Совокупный портфель" selection into the full list of broker accounts
- fetch portfolio, positions, and operations for each account and merge cash, positions, and history data
- update connection metadata to keep the combined account id and avoid API calls without account ids
- adjust passive income analytics to subtract cash contributions so invested salary isn’t counted as passive income

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68f01ed37a288330a0ad6968917c2066